### PR TITLE
L4s dev double prob

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ Makefile.in
 /src/frontend/mm-webreplay
 /src/frontend/mm-replayserver
 /src/frontend/.libs
+/.vscode/
+/build/
+/configure~

--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@ AC_CONFIG_MACRO_DIR([m4])
 
 # Add picky CXXFLAGS
 CXX11_FLAGS="-std=c++11 -pthread"
-PICKY_CXXFLAGS="-pedantic -Wall -Wextra -Weffc++ -Werror"
+PICKY_CXXFLAGS="-pedantic -Wall -Wextra -Weffc++"
 AC_SUBST([CXX11_FLAGS])
 AC_SUBST([PICKY_CXXFLAGS])
 

--- a/src/frontend/Makefile.am
+++ b/src/frontend/Makefile.am
@@ -3,32 +3,32 @@ AM_CXXFLAGS = $(PICKY_CXXFLAGS)
 
 bin_PROGRAMS = mm-delay
 mm_delay_SOURCES = delayshell.cc delay_queue.hh delay_queue.cc
-mm_delay_LDADD = -lrt ../util/libutil.a ../packet/libpacket.a
+mm_delay_LDADD = -lrt ../packet/libpacket.a ../util/libutil.a
 mm_delay_LDFLAGS = -pthread
 
 bin_PROGRAMS += mm-loss
 mm_loss_SOURCES = lossshell.cc loss_queue.hh loss_queue.cc
-mm_loss_LDADD = -lrt ../util/libutil.a ../packet/libpacket.a
+mm_loss_LDADD = -lrt ../packet/libpacket.a ../util/libutil.a
 mm_loss_LDFLAGS = -pthread
 
 bin_PROGRAMS += mm-onoff
 mm_onoff_SOURCES = onoffshell.cc loss_queue.hh loss_queue.cc
-mm_onoff_LDADD = -lrt ../util/libutil.a ../packet/libpacket.a
+mm_onoff_LDADD = -lrt ../packet/libpacket.a ../util/libutil.a
 mm_onoff_LDFLAGS = -pthread
 
 bin_PROGRAMS += mm-intermittent
 mm_intermittent_SOURCES = intermittentshell.cc loss_queue.hh loss_queue.cc
-mm_intermittent_LDADD = -lrt ../util/libutil.a ../packet/libpacket.a
+mm_intermittent_LDADD = -lrt ../packet/libpacket.a ../util/libutil.a
 mm_intermittent_LDFLAGS = -pthread
 
 bin_PROGRAMS += mm-link
 mm_link_SOURCES = linkshell.cc link_queue.hh link_queue.cc
-mm_link_LDADD = -lrt ../util/libutil.a ../packet/libpacket.a ../graphing/libgraph.a $(XCBPRESENT_LIBS) $(XCB_LIBS) $(PANGOCAIRO_LIBS)
+mm_link_LDADD = -lrt ../packet/libpacket.a ../graphing/libgraph.a ../util/libutil.a $(XCBPRESENT_LIBS) $(XCB_LIBS) $(PANGOCAIRO_LIBS)
 mm_link_LDFLAGS = -pthread
 
 bin_PROGRAMS += mm-meter
 mm_meter_SOURCES = meter.cc meter_queue.hh meter_queue.cc
-mm_meter_LDADD = -lrt ../util/libutil.a ../packet/libpacket.a ../graphing/libgraph.a $(XCBPRESENT_LIBS) $(XCB_LIBS) $(PANGOCAIRO_LIBS)
+mm_meter_LDADD = -lrt ../packet/libpacket.a ../graphing/libgraph.a ../util/libutil.a $(XCBPRESENT_LIBS) $(XCB_LIBS) $(PANGOCAIRO_LIBS)
 mm_meter_LDFLAGS = -pthread
 
 bin_PROGRAMS += mm-webrecord
@@ -38,12 +38,12 @@ mm_webrecord_LDFLAGS = -pthread
 
 bin_PROGRAMS += mm-webreplay
 mm_webreplay_SOURCES = replayshell.cc web_server.hh web_server.cc
-mm_webreplay_LDADD = -lrt ../util/libutil.a ../http/libhttp.a ../protobufs/libhttprecordprotos.a $(protobuf_LIBS)
+mm_webreplay_LDADD = -lrt ../http/libhttp.a ../protobufs/libhttprecordprotos.a ../util/libutil.a $(protobuf_LIBS)
 mm_webreplay_LDFLAGS = -pthread
 
 bin_PROGRAMS += mm-replayserver
 mm_replayserver_SOURCES = replayserver.cc
-mm_replayserver_LDADD = -lrt ../util/libutil.a ../http/libhttp.a ../protobufs/libhttprecordprotos.a $(protobuf_LIBS)
+mm_replayserver_LDADD = -lrt ../http/libhttp.a ../protobufs/libhttprecordprotos.a ../util/libutil.a $(protobuf_LIBS)
 mm_replayserver_LDFLAGS = -pthread
 
 lib_LTLIBRARIES = libmod_deepcgi.la

--- a/src/frontend/linkshell.cc
+++ b/src/frontend/linkshell.cc
@@ -7,6 +7,7 @@
 #include "drop_head_packet_queue.hh"
 #include "codel_packet_queue.hh"
 #include "pie_packet_queue.hh"
+#include "dualq_coupled_aqm.hh"
 #include "link_queue.hh"
 #include "packetshell.cc"
 
@@ -24,9 +25,11 @@ void usage_error( const string & program_name )
     cerr << "          --uplink-queue=QUEUE_TYPE --downlink-queue=QUEUE_TYPE" << endl;
     cerr << "          --uplink-queue-args=QUEUE_ARGS --downlink-queue-args=QUEUE_ARGS" << endl;
     cerr << endl;
-    cerr << "          QUEUE_TYPE = infinite | droptail | drophead | codel | pie" << endl;
+    cerr << "          QUEUE_TYPE = infinite | droptail | drophead | codel | pie | dualPI2" << endl;
     cerr << "          QUEUE_ARGS = \"NAME=NUMBER[, NAME2=NUMBER2, ...]\"" << endl;
     cerr << "              (with NAME = bytes | packets | target | interval | qdelay_ref | max_burst)" << endl;
+    // TODO: DualPI2 - add the required params
+
     cerr << "                  target, interval, qdelay_ref, max_burst are in milli-second" << endl << endl;
 
     throw runtime_error( "invalid arguments" );
@@ -44,6 +47,8 @@ unique_ptr<AbstractPacketQueue> get_packet_queue( const string & type, const str
         return unique_ptr<AbstractPacketQueue>( new CODELPacketQueue( args ) );
     } else if ( type == "pie" ) {
         return unique_ptr<AbstractPacketQueue>( new PIEPacketQueue( args ) );
+    } else if ( type == "dualPI2" ) {
+        return unique_ptr<AbstractPacketQueue>( new DualQCoupledAQM( args ) );
     } else {
         cerr << "Unknown queue type: " << type << endl;
     }

--- a/src/packet/Makefile.am
+++ b/src/packet/Makefile.am
@@ -8,4 +8,7 @@ libpacket_a_SOURCES = packetshell.hh packetshell.cc queued_packet.hh \
                       drop_tail_packet_queue.hh drop_head_packet_queue.hh \
                       codel_packet_queue.cc codel_packet_queue.hh \
                       pie_packet_queue.cc pie_packet_queue.hh \
+                      dualq_coupled_aqm.cc dualq_coupled_aqm.hh \
+                      classic_packet_queue.cc classic_packet_queue.hh \
+                      l4s_packet_queue.cc l4s_packet_queue.hh \
                       bindworkaround.hh

--- a/src/packet/Makefile.am
+++ b/src/packet/Makefile.am
@@ -9,6 +9,9 @@ libpacket_a_SOURCES = packetshell.hh packetshell.cc queued_packet.hh \
                       codel_packet_queue.cc codel_packet_queue.hh \
                       pie_packet_queue.cc pie_packet_queue.hh \
                       dualq_coupled_aqm.cc dualq_coupled_aqm.hh \
+                      abstract_dualpi2_packet_queue.cc abstract_dualpi2_packet_queue.hh \
                       classic_packet_queue.cc classic_packet_queue.hh \
                       l4s_packet_queue.cc l4s_packet_queue.hh \
+                      abstract_l4s_scheduler.hh \
+                      weighted_round_robin_scheduler.cc weighted_round_robin_scheduler.hh \
                       bindworkaround.hh

--- a/src/packet/abstract_dualpi2_packet_queue.cc
+++ b/src/packet/abstract_dualpi2_packet_queue.cc
@@ -1,0 +1,15 @@
+#include <chrono>
+
+#include "abstract_dualpi2_packet_queue.hh"
+#include "timestamp.hh"
+
+using namespace std;
+
+#define DQ_COUNT_INVALID   (uint32_t)-1
+
+AbstractDualPI2PacketQueue::AbstractDualPI2PacketQueue( const string & args )
+  : DroppingPacketQueue(args)
+{
+  
+}
+

--- a/src/packet/abstract_dualpi2_packet_queue.cc
+++ b/src/packet/abstract_dualpi2_packet_queue.cc
@@ -13,3 +13,12 @@ AbstractDualPI2PacketQueue::AbstractDualPI2PacketQueue( const string & args )
   
 }
 
+// TODO: Is there a better place for this function?
+uint32_t scale_prob( double prob )
+{
+    if ( prob < 0.0 || prob > 1.0 )
+        throw runtime_error ("Probability out of range! Provided value: " + std::to_string(prob));
+
+    return static_cast<uint32_t> ( prob * MAX_PROB ) ;
+}
+

--- a/src/packet/abstract_dualpi2_packet_queue.cc
+++ b/src/packet/abstract_dualpi2_packet_queue.cc
@@ -93,14 +93,6 @@ uint64_t AbstractDualPI2PacketQueue::qdelay_in_ms ( uint64_t ref )
     return ref - head.arrival_time;
 }
 
-uint32_t scale_prob( double prob )
-{
-    if ( prob < 0.0 || prob > 1.0 )
-        throw runtime_error ("Probability out of range! Provided value: " + std::to_string(prob));
-
-    return static_cast<uint32_t> ( prob * MAX_PROB ) ;
-}
-
 unsigned int get_arg( const string & args, const string & name )
 {
     return DroppingPacketQueue::get_arg( args, name );

--- a/src/packet/abstract_dualpi2_packet_queue.cc
+++ b/src/packet/abstract_dualpi2_packet_queue.cc
@@ -92,6 +92,8 @@ uint64_t AbstractDualPI2PacketQueue::qdelay_in_ms ( uint64_t ref )
     return ref - head.arrival_time;
 }
 
+// Utilities
+
 unsigned int get_arg( const string & args, const string & name )
 {
     return DroppingPacketQueue::get_arg( args, name );
@@ -144,4 +146,29 @@ void print_ipv4_header( QueuedPacket & p )
     struct in_addr dip;
     dip.s_addr = ip_header->daddr;
     //std::cout << "Destination IP: " << inet_ntoa(dip) << std::endl;
+}
+
+/* Calculate_ip_checksum function, borrowed from:
+   https://github.com/prateshg/ABC-NSDI2020/mahimahi/src/packet/cellular_packet_queue.hh*/
+
+/* set ip checksum of a given ip header*/
+/* Compute checksum for count bytes starting at addr, using one's complement of one's complement sum*/
+unsigned short calculate_ip_checksum(unsigned short *addr, unsigned int count) 
+{
+    register unsigned long sum = 0;
+    while (count > 1) {
+        sum += * addr++;
+        count -= 2;
+    }
+    //if any bytes left, pad the bytes and add
+    if(count > 0) {
+        sum += ((*addr)&htons(0xFF00));
+    }
+    //Fold sum to 16 bits: add carrier to result
+    while (sum>>16) {
+        sum = (sum & 0xffff) + (sum >> 16);
+    }
+    //one's complement
+    sum = ~sum;
+    return ((unsigned short)sum);
 }

--- a/src/packet/abstract_dualpi2_packet_queue.cc
+++ b/src/packet/abstract_dualpi2_packet_queue.cc
@@ -4,15 +4,24 @@
 #include "dropping_packet_queue.hh"
 #include "timestamp.hh"
 
-using namespace std;
+#include <netinet/ip.h>
+#include <arpa/inet.h>
 
-#define DQ_COUNT_INVALID   (uint32_t)-1
+#include <cstddef>
+
+using namespace std;
 
 void AbstractDualPI2PacketQueue::enqueue( QueuedPacket && p )
 {
+    std::cout << "> In enqueue. Packet of size "<< p.contents.size()  << " to enqueue: "  <<  std::endl;
+    print_ipv4_header( p ) ;
+
     queue_size_in_bytes_ += p.contents.size();
     queue_size_in_packets_++;
     internal_queue_.emplace( std::move( p ) );
+    
+    std::cout << "> In enqueue. Queue size is " << size_bytes() << " bytes, or " << size_packets() 
+    << " packets." <<  std::endl;
 }
 
 QueuedPacket AbstractDualPI2PacketQueue::dequeue( void )
@@ -24,6 +33,9 @@ QueuedPacket AbstractDualPI2PacketQueue::dequeue( void )
 
     queue_size_in_bytes_ -= ret.contents.size();
     queue_size_in_packets_--;
+
+    std::cout << "> In dequeue. Queue size is " << size_bytes() << " bytes, or " << size_packets() 
+    << " packets." <<  std::endl;
 
     return ret;
 }
@@ -91,7 +103,54 @@ uint32_t scale_prob( double prob )
 
 unsigned int get_arg( const string & args, const string & name )
 {
-    std::cout << " Got into get_arg!!!\n";
     return DroppingPacketQueue::get_arg( args, name );
 }
 
+void print_ipv4_header( QueuedPacket & p ) 
+{
+    std::cout << "-- PRE IP Header Information:" << std::endl;
+
+    std::cout << std::to_string(p.contents[0]) << std::endl;
+    std::cout << std::to_string(p.contents[1]) << std::endl;
+    std::cout << std::to_string(p.contents[2]) << std::endl;
+    std::cout << std::to_string(p.contents[3]) << std::endl;
+
+    
+    std::cout << "-- IP Header Information:" << std::endl;
+    
+    struct iphdr *ip_header = (struct iphdr *) &p.contents[4];
+    // Version and Header Length
+    std::cout << "Version: " << (int)ip_header->version << std::endl;
+    std::cout << "Header Length: " << (int)ip_header->ihl * 4 << " bytes" << std::endl;
+    
+    // Type of Service
+    std::cout << "Type of Service: " << std::to_string(ip_header->tos) << std::endl;
+
+    // Total Length
+    std::cout << "Total Length: " << ntohs(ip_header->tot_len) << " bytes" << std::endl;
+
+    // Identification
+    std::cout << "Identification: " << ntohs(ip_header->id) << std::endl;
+
+    // Flags and Fragment Offset
+    std::cout << "Flags: " << (int)ip_header->frag_off << std::endl;
+
+    // Time to Live
+    std::cout << "TTL: " << (int)ip_header->ttl << std::endl;
+
+    // Protocol
+    std::cout << "Protocol: " << (int)ip_header->protocol << std::endl;
+
+    // Header Checksum
+    std::cout << "Checksum: " << ntohs(ip_header->check) << std::endl;
+
+    // Source IP Address
+    struct in_addr sip;
+    sip.s_addr = ip_header->saddr;
+    std::cout << "Source IP: " << inet_ntoa(sip) << std::endl;
+
+    // Destination IP Address
+    struct in_addr dip;
+    dip.s_addr = ip_header->daddr;
+    std::cout << "Destination IP: " << inet_ntoa(dip) << std::endl;
+}

--- a/src/packet/abstract_dualpi2_packet_queue.cc
+++ b/src/packet/abstract_dualpi2_packet_queue.cc
@@ -85,12 +85,12 @@ QueuedPacket& AbstractDualPI2PacketQueue::peek( void )
     return internal_queue_.front();
 }
 
-uint64_t AbstractDualPI2PacketQueue::qdelay_in_ns ( uint64_t ref ) 
+uint64_t AbstractDualPI2PacketQueue::qdelay_in_ms ( uint64_t ref ) 
 {
     if ( internal_queue_.empty() ) return 0;
     
     QueuedPacket& head = peek();
-    return head.sojourn_time_in_ns( ref );
+    return ref - head.arrival_time;
 }
 
 uint32_t scale_prob( double prob )

--- a/src/packet/abstract_dualpi2_packet_queue.cc
+++ b/src/packet/abstract_dualpi2_packet_queue.cc
@@ -1,17 +1,84 @@
 #include <chrono>
 
 #include "abstract_dualpi2_packet_queue.hh"
+#include "dropping_packet_queue.hh"
 #include "timestamp.hh"
 
 using namespace std;
 
 #define DQ_COUNT_INVALID   (uint32_t)-1
 
-AbstractDualPI2PacketQueue::AbstractDualPI2PacketQueue( const string & args )
-  : DroppingPacketQueue(args),
-    recur_count_ (0)
+void AbstractDualPI2PacketQueue::enqueue( QueuedPacket && p )
 {
-  
+    queue_size_in_bytes_ += p.contents.size();
+    queue_size_in_packets_++;
+    internal_queue_.emplace( std::move( p ) );
+}
+
+QueuedPacket AbstractDualPI2PacketQueue::dequeue( void )
+{
+    assert( not internal_queue_.empty() );
+
+    QueuedPacket ret = std::move( internal_queue_.front() );
+    internal_queue_.pop();
+
+    queue_size_in_bytes_ -= ret.contents.size();
+    queue_size_in_packets_--;
+
+    return ret;
+}
+
+bool AbstractDualPI2PacketQueue::empty( void ) const
+{
+    return internal_queue_.empty();
+}
+
+unsigned int AbstractDualPI2PacketQueue::size_bytes( void ) const
+{
+    assert( queue_size_in_bytes_ >= 0 );
+    return unsigned( queue_size_in_bytes_ );
+}
+
+unsigned int AbstractDualPI2PacketQueue::size_packets( void ) const
+{
+    assert( queue_size_in_packets_ >= 0 );
+    return unsigned( queue_size_in_packets_ );
+}
+
+
+
+string AbstractDualPI2PacketQueue::to_string( void ) const
+{
+    // string ret = type() + " [";
+
+    // if ( byte_limit_ ) {
+    //     ret += string( "bytes=" ) + ::to_string( byte_limit_ );
+    // }
+
+    // if ( packet_limit_ ) {
+    //     if ( byte_limit_ ) {
+    //         ret += ", ";
+    //     }
+
+    //     ret += string( "packets=" ) + ::to_string( packet_limit_ );
+    // }
+
+    // ret += "]";
+
+    return "";
+}
+
+QueuedPacket& AbstractDualPI2PacketQueue::peek( void ) 
+{
+    return internal_queue_.front();
+}
+
+uint64_t AbstractDualPI2PacketQueue::qdelay_in_ns ( uint64_t ref ) 
+{
+    if ( internal_queue_.empty() ) return 0;
+    
+    QueuedPacket& head = peek();
+    return head.sojourn_time_in_ns( ref );
 }
 
 uint32_t scale_prob( double prob )
@@ -20,5 +87,11 @@ uint32_t scale_prob( double prob )
         throw runtime_error ("Probability out of range! Provided value: " + std::to_string(prob));
 
     return static_cast<uint32_t> ( prob * MAX_PROB ) ;
+}
+
+unsigned int get_arg( const string & args, const string & name )
+{
+    std::cout << " Got into get_arg!!!\n";
+    return DroppingPacketQueue::get_arg( args, name );
 }
 

--- a/src/packet/abstract_dualpi2_packet_queue.cc
+++ b/src/packet/abstract_dualpi2_packet_queue.cc
@@ -34,8 +34,7 @@ QueuedPacket AbstractDualPI2PacketQueue::dequeue( void )
     queue_size_in_bytes_ -= ret.contents.size();
     queue_size_in_packets_--;
 
-    std::cout << "> In dequeue. Queue size is " << size_bytes() << " bytes, or " << size_packets() 
-    << " packets." <<  std::endl;
+    //std::cout << "> In dequeue. Queue size is " << size_bytes() << " bytes, or " << size_packets() << " packets." <<  std::endl;
 
     return ret;
 }
@@ -100,49 +99,49 @@ unsigned int get_arg( const string & args, const string & name )
 
 void print_ipv4_header( QueuedPacket & p ) 
 {
-    std::cout << "-- PRE IP Header Information:" << std::endl;
+    //std::cout << "-- PRE IP Header Information:" << std::endl;
 
-    std::cout << std::to_string(p.contents[0]) << std::endl;
-    std::cout << std::to_string(p.contents[1]) << std::endl;
-    std::cout << std::to_string(p.contents[2]) << std::endl;
-    std::cout << std::to_string(p.contents[3]) << std::endl;
+    //std::cout << std::to_string(p.contents[0]) << std::endl;
+    //std::cout << std::to_string(p.contents[1]) << std::endl;
+    //std::cout << std::to_string(p.contents[2]) << std::endl;
+    //std::cout << std::to_string(p.contents[3]) << std::endl;
 
     
-    std::cout << "-- IP Header Information:" << std::endl;
+    //std::cout << "-- IP Header Information:" << std::endl;
     
     struct iphdr *ip_header = (struct iphdr *) &p.contents[4];
     // Version and Header Length
-    std::cout << "Version: " << (int)ip_header->version << std::endl;
-    std::cout << "Header Length: " << (int)ip_header->ihl * 4 << " bytes" << std::endl;
+    //std::cout << "Version: " << (int)ip_header->version << std::endl;
+    //std::cout << "Header Length: " << (int)ip_header->ihl * 4 << " bytes" << std::endl;
     
     // Type of Service
-    std::cout << "Type of Service: " << std::to_string(ip_header->tos) << std::endl;
+    //std::cout << "Type of Service: " << std::to_string(ip_header->tos) << std::endl;
 
     // Total Length
-    std::cout << "Total Length: " << ntohs(ip_header->tot_len) << " bytes" << std::endl;
+    //std::cout << "Total Length: " << ntohs(ip_header->tot_len) << " bytes" << std::endl;
 
     // Identification
-    std::cout << "Identification: " << ntohs(ip_header->id) << std::endl;
+    //std::cout << "Identification: " << ntohs(ip_header->id) << std::endl;
 
     // Flags and Fragment Offset
-    std::cout << "Flags: " << (int)ip_header->frag_off << std::endl;
+    //std::cout << "Flags: " << (int)ip_header->frag_off << std::endl;
 
     // Time to Live
-    std::cout << "TTL: " << (int)ip_header->ttl << std::endl;
+    //std::cout << "TTL: " << (int)ip_header->ttl << std::endl;
 
     // Protocol
-    std::cout << "Protocol: " << (int)ip_header->protocol << std::endl;
+    //std::cout << "Protocol: " << (int)ip_header->protocol << std::endl;
 
     // Header Checksum
-    std::cout << "Checksum: " << ntohs(ip_header->check) << std::endl;
+    //std::cout << "Checksum: " << ntohs(ip_header->check) << std::endl;
 
     // Source IP Address
     struct in_addr sip;
     sip.s_addr = ip_header->saddr;
-    std::cout << "Source IP: " << inet_ntoa(sip) << std::endl;
+    //std::cout << "Source IP: " << inet_ntoa(sip) << std::endl;
 
     // Destination IP Address
     struct in_addr dip;
     dip.s_addr = ip_header->daddr;
-    std::cout << "Destination IP: " << inet_ntoa(dip) << std::endl;
+    //std::cout << "Destination IP: " << inet_ntoa(dip) << std::endl;
 }

--- a/src/packet/abstract_dualpi2_packet_queue.cc
+++ b/src/packet/abstract_dualpi2_packet_queue.cc
@@ -8,12 +8,12 @@ using namespace std;
 #define DQ_COUNT_INVALID   (uint32_t)-1
 
 AbstractDualPI2PacketQueue::AbstractDualPI2PacketQueue( const string & args )
-  : DroppingPacketQueue(args)
+  : DroppingPacketQueue(args),
+    recur_count_ (0)
 {
   
 }
 
-// TODO: Is there a better place for this function?
 uint32_t scale_prob( double prob )
 {
     if ( prob < 0.0 || prob > 1.0 )

--- a/src/packet/abstract_dualpi2_packet_queue.hh
+++ b/src/packet/abstract_dualpi2_packet_queue.hh
@@ -7,6 +7,8 @@
 #include <thread>
 #include "dropping_packet_queue.hh"
 
+/* Max value of an 32-bit integer */
+#define MAX_PROB ((uint32_t)(~((uint32_t)0)))
 
 class AbstractDualPI2PacketQueue : public DroppingPacketQueue
 {

--- a/src/packet/abstract_dualpi2_packet_queue.hh
+++ b/src/packet/abstract_dualpi2_packet_queue.hh
@@ -1,0 +1,30 @@
+/* -*-mode:c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#ifndef ABSTRACT_DUALPI2_PACKET_QUEUE_HH
+#define ABSTRACT_DUALPI2_PACKET_QUEUE_HH
+
+#include <random>
+#include <thread>
+#include "dropping_packet_queue.hh"
+
+
+class AbstractDualPI2PacketQueue : public DroppingPacketQueue
+{
+protected:
+    //This constant is copied from link_queue.hh.
+    //It maybe better to get this in a more reliable way in the future.
+    const static unsigned int PACKET_SIZE = 1504; /* default max TUN payload size */
+
+    uint32_t recur_count_;
+
+
+public:
+    AbstractDualPI2PacketQueue( const std::string & args );
+
+    virtual void enqueue( QueuedPacket && p ) = 0;
+
+    uint32_t get_recur_count ( void ) { return recur_count_; } 
+    void set_recur_count ( uint32_t val ) { recur_count_ = val; }
+};
+
+#endif /* ABSTRACT_DUALPI2_PACKET_QUEUE_HH */

--- a/src/packet/abstract_dualpi2_packet_queue.hh
+++ b/src/packet/abstract_dualpi2_packet_queue.hh
@@ -29,4 +29,7 @@ public:
     void set_recur_count ( uint32_t val ) { recur_count_ = val; }
 };
 
+// TODO: Is there a better place for this function?
+uint32_t scale_prob( double prob );
+
 #endif /* ABSTRACT_DUALPI2_PACKET_QUEUE_HH */

--- a/src/packet/abstract_dualpi2_packet_queue.hh
+++ b/src/packet/abstract_dualpi2_packet_queue.hh
@@ -3,32 +3,55 @@
 #ifndef ABSTRACT_DUALPI2_PACKET_QUEUE_HH
 #define ABSTRACT_DUALPI2_PACKET_QUEUE_HH
 
-#include <random>
-#include <thread>
-#include "dropping_packet_queue.hh"
+#include <queue>
+// #include <cassert>
+
+// #include <random>
+// #include <thread>
+
+#include "abstract_packet_queue.hh"
 
 /* Max value of an 32-bit integer */
 #define MAX_PROB ((uint32_t)(~((uint32_t)0)))
 
-class AbstractDualPI2PacketQueue : public DroppingPacketQueue
+class AbstractDualPI2PacketQueue : public AbstractPacketQueue
 {
+private:
+    int queue_size_in_bytes_ = 0, queue_size_in_packets_ = 0;
+
+    std::queue<QueuedPacket> internal_queue_ {};
+
+    virtual const std::string & type( void ) const = 0;
+
+    uint32_t recur_count_ = 0;
+
 protected:
-    //This constant is copied from link_queue.hh.
-    //It maybe better to get this in a more reliable way in the future.
-    const static unsigned int PACKET_SIZE = 1504; /* default max TUN payload size */
-
-    uint32_t recur_count_;
-
+    
 
 public:
-    AbstractDualPI2PacketQueue( const std::string & args );
+    void enqueue( QueuedPacket && p );
 
-    virtual void enqueue( QueuedPacket && p ) = 0;
+    QueuedPacket dequeue( void );
+
+    bool empty( void ) const override;
+
+    std::string to_string( void ) const override;
+
+    unsigned int size_bytes( void ) const override;
+    unsigned int size_packets( void ) const override;
 
     uint32_t get_recur_count ( void ) { return recur_count_; } 
     void set_recur_count ( uint32_t val ) { recur_count_ = val; }
+
+    QueuedPacket& peek ( void );
+    uint64_t qdelay_in_ns ( uint64_t ref );
+
+        
 };
 
+
+// Utilities
 uint32_t scale_prob( double prob );
+unsigned int get_arg( const std::string & args, const std::string & name );
 
 #endif /* ABSTRACT_DUALPI2_PACKET_QUEUE_HH */

--- a/src/packet/abstract_dualpi2_packet_queue.hh
+++ b/src/packet/abstract_dualpi2_packet_queue.hh
@@ -49,5 +49,7 @@ public:
 // Utilities
 unsigned int get_arg( const std::string & args, const std::string & name );
 void print_ipv4_header( QueuedPacket & p ); 
+unsigned short calculate_ip_checksum(unsigned short *addr, unsigned int count); 
+
 
 #endif /* ABSTRACT_DUALPI2_PACKET_QUEUE_HH */

--- a/src/packet/abstract_dualpi2_packet_queue.hh
+++ b/src/packet/abstract_dualpi2_packet_queue.hh
@@ -44,7 +44,7 @@ public:
     void set_recur_count ( uint64_t val ) { recur_count_ = val; }
 
     QueuedPacket& peek ( void );
-    uint64_t qdelay_in_ns ( uint64_t ref );       
+    uint64_t qdelay_in_ms ( uint64_t ref );       
 };
 
 

--- a/src/packet/abstract_dualpi2_packet_queue.hh
+++ b/src/packet/abstract_dualpi2_packet_queue.hh
@@ -29,7 +29,6 @@ public:
     void set_recur_count ( uint32_t val ) { recur_count_ = val; }
 };
 
-// TODO: Is there a better place for this function?
 uint32_t scale_prob( double prob );
 
 #endif /* ABSTRACT_DUALPI2_PACKET_QUEUE_HH */

--- a/src/packet/abstract_dualpi2_packet_queue.hh
+++ b/src/packet/abstract_dualpi2_packet_queue.hh
@@ -23,7 +23,7 @@ private:
 
     virtual const std::string & type( void ) const = 0;
 
-    uint32_t recur_count_ = 0;
+    uint64_t recur_count_ = 0;
 
 protected:
     
@@ -40,18 +40,17 @@ public:
     unsigned int size_bytes( void ) const override;
     unsigned int size_packets( void ) const override;
 
-    uint32_t get_recur_count ( void ) { return recur_count_; } 
-    void set_recur_count ( uint32_t val ) { recur_count_ = val; }
+    uint64_t get_recur_count ( void ) { return recur_count_; } 
+    void set_recur_count ( uint64_t val ) { recur_count_ = val; }
 
     QueuedPacket& peek ( void );
-    uint64_t qdelay_in_ns ( uint64_t ref );
-
-        
+    uint64_t qdelay_in_ns ( uint64_t ref );       
 };
 
 
 // Utilities
 uint32_t scale_prob( double prob );
 unsigned int get_arg( const std::string & args, const std::string & name );
+void print_ipv4_header( QueuedPacket & p ); 
 
 #endif /* ABSTRACT_DUALPI2_PACKET_QUEUE_HH */

--- a/src/packet/abstract_dualpi2_packet_queue.hh
+++ b/src/packet/abstract_dualpi2_packet_queue.hh
@@ -11,8 +11,6 @@
 
 #include "abstract_packet_queue.hh"
 
-/* Max value of an 32-bit integer */
-#define MAX_PROB ((uint32_t)(~((uint32_t)0)))
 
 class AbstractDualPI2PacketQueue : public AbstractPacketQueue
 {
@@ -49,7 +47,6 @@ public:
 
 
 // Utilities
-uint32_t scale_prob( double prob );
 unsigned int get_arg( const std::string & args, const std::string & name );
 void print_ipv4_header( QueuedPacket & p ); 
 

--- a/src/packet/abstract_dualpi2_packet_queue.hh
+++ b/src/packet/abstract_dualpi2_packet_queue.hh
@@ -21,7 +21,7 @@ private:
 
     virtual const std::string & type( void ) const = 0;
 
-    uint64_t recur_count_ = 0;
+    double recur_count_ = 0.0;
 
 protected:
     
@@ -38,8 +38,8 @@ public:
     unsigned int size_bytes( void ) const override;
     unsigned int size_packets( void ) const override;
 
-    uint64_t get_recur_count ( void ) { return recur_count_; } 
-    void set_recur_count ( uint64_t val ) { recur_count_ = val; }
+    double get_recur_count ( void ) { return recur_count_; } 
+    void set_recur_count ( double val ) { recur_count_ = val; }
 
     QueuedPacket& peek ( void );
     uint64_t qdelay_in_ms ( uint64_t ref );       

--- a/src/packet/abstract_l4s_scheduler.hh
+++ b/src/packet/abstract_l4s_scheduler.hh
@@ -8,6 +8,11 @@
 #include "l4s_packet_queue.hh"
 #include "classic_packet_queue.hh"
 
+// default max TUN payload size from link_queue.hh.
+// equal to PACKET_SIZE in dualq_coupled_aqm 
+
+# define MTU 1504
+
 enum class QueueType {
     NONE,
     L4S,

--- a/src/packet/abstract_l4s_scheduler.hh
+++ b/src/packet/abstract_l4s_scheduler.hh
@@ -9,6 +9,7 @@
 #include "classic_packet_queue.hh"
 
 enum class QueueType {
+    NONE,
     L4S,
     Classic
 };

--- a/src/packet/abstract_l4s_scheduler.hh
+++ b/src/packet/abstract_l4s_scheduler.hh
@@ -1,0 +1,42 @@
+/* -*-mode:c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#ifndef ABSTRACT_L4S_SCHEDULER
+#define ABSTRACT_L4S_SCHEDULER
+
+#include <string>
+
+#include "l4s_packet_queue.hh"
+#include "classic_packet_queue.hh"
+
+enum class QueueType {
+    L4S,
+    Classic
+};
+
+enum class SchedulerType {
+    NONE,
+    WRR,
+    TS_FIFO
+};
+
+class AbstractL4SScheduler
+{
+protected:
+    // Dual queues
+    L4SPacketQueue & l4s_queue_;
+    CLASSICPacketQueue & classic_queue_;
+
+public:
+
+    AbstractL4SScheduler (L4SPacketQueue & l4s_q, CLASSICPacketQueue & classic_q) : 
+        l4s_queue_ ( l4s_q ),
+        classic_queue_( classic_q )
+        {};
+
+    virtual QueueType select_queue( void ) = 0;
+
+    virtual ~AbstractL4SScheduler() = default;
+
+};
+
+#endif /* ABSTRACT_L4S_SCHEDULER */ 

--- a/src/packet/classic_packet_queue.cc
+++ b/src/packet/classic_packet_queue.cc
@@ -1,0 +1,53 @@
+#include <chrono>
+
+#include "classic_packet_queue.hh"
+#include "timestamp.hh"
+
+using namespace std;
+
+#define DQ_COUNT_INVALID   (uint32_t)-1
+
+CLASSICPacketQueue::CLASSICPacketQueue( const string & args )
+  : DroppingPacketQueue(args)
+{
+    /*
+    if ( qdelay_ref_ == 0 || max_burst_ == 0 ) {
+      throw runtime_error( "PIE AQM queue must have qdelay_ref and max_burst parameters" );
+    }
+     */
+}
+
+void CLASSICPacketQueue::enqueue( QueuedPacket && p )
+{
+    calculate_drop_prob();
+
+
+
+    assert( good() );
+}
+
+//returns true if packet should be dropped.
+bool CLASSICPacketQueue::drop_early ()
+{
+
+    return false;
+}
+
+QueuedPacket CLASSICPacketQueue::dequeue( void )
+{
+    QueuedPacket ret = std::move( DroppingPacketQueue::dequeue () );
+    uint32_t now = timestamp();
+
+
+
+    return ret;
+}
+
+void CLASSICPacketQueue::calculate_drop_prob( void )
+{
+    uint64_t now = timestamp();
+
+
+
+
+}

--- a/src/packet/classic_packet_queue.cc
+++ b/src/packet/classic_packet_queue.cc
@@ -5,16 +5,10 @@
 
 using namespace std;
 
-#define DQ_COUNT_INVALID   (uint32_t)-1
-
 CLASSICPacketQueue::CLASSICPacketQueue( const string & args )
-  : DroppingPacketQueue(args)
+  : AbstractDualPI2PacketQueue(args)
 {
-    /*
-    if ( qdelay_ref_ == 0 || max_burst_ == 0 ) {
-      throw runtime_error( "PIE AQM queue must have qdelay_ref and max_burst parameters" );
-    }
-     */
+  
 }
 
 void CLASSICPacketQueue::enqueue( QueuedPacket && p )
@@ -35,6 +29,7 @@ bool CLASSICPacketQueue::drop_early ()
 
 QueuedPacket CLASSICPacketQueue::dequeue( void )
 {
+    // TODO: Check if keep the DroppingPacketqueue link below
     QueuedPacket ret = std::move( DroppingPacketQueue::dequeue () );
     uint32_t now = timestamp();
 

--- a/src/packet/classic_packet_queue.cc
+++ b/src/packet/classic_packet_queue.cc
@@ -6,43 +6,8 @@
 using namespace std;
 
 CLASSICPacketQueue::CLASSICPacketQueue( const string & args )
-  : AbstractDualPI2PacketQueue(args)
 {
   
 }
 
-void CLASSICPacketQueue::enqueue( QueuedPacket && p )
-{
-    calculate_drop_prob();
 
-
-
-    assert( good() );
-}
-
-//returns true if packet should be dropped.
-bool CLASSICPacketQueue::drop_early ()
-{
-
-    return false;
-}
-
-QueuedPacket CLASSICPacketQueue::dequeue( void )
-{
-    // TODO: Check if keep the DroppingPacketqueue link below
-    QueuedPacket ret = std::move( DroppingPacketQueue::dequeue () );
-    uint32_t now = timestamp();
-
-
-
-    return ret;
-}
-
-void CLASSICPacketQueue::calculate_drop_prob( void )
-{
-    uint64_t now = timestamp();
-
-
-
-
-}

--- a/src/packet/classic_packet_queue.hh
+++ b/src/packet/classic_packet_queue.hh
@@ -1,0 +1,42 @@
+/* -*-mode:c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#ifndef CLASSIC_PACKET_QUEUE_HH
+#define CLASSIC_PACKET_QUEUE_HH
+
+#include <random>
+#include <thread>
+#include "dropping_packet_queue.hh"
+
+/*
+   Classic queue implementation as part of the DualPI2 implentation described in RFC 9332.
+*/
+
+class CLASSICPacketQueue : public DroppingPacketQueue
+{
+private:
+    //This constant is copied from link_queue.hh.
+    //It maybe better to get this in a more reliable way in the future.
+    const static unsigned int PACKET_SIZE = 1504; /* default max TUN payload size */
+
+
+
+
+    virtual const std::string & type( void ) const override
+    {
+        static const std::string type_ { "classic" };
+        return type_;
+    }
+
+    bool drop_early ( void );
+
+    void calculate_drop_prob ( void );
+
+public:
+    CLASSICPacketQueue( const std::string & args );
+
+    void enqueue( QueuedPacket && p ) override;
+
+    QueuedPacket dequeue( void ) override;
+};
+
+#endif /* CLASSIC_PACKET_QUEUE_HH */

--- a/src/packet/classic_packet_queue.hh
+++ b/src/packet/classic_packet_queue.hh
@@ -5,21 +5,15 @@
 
 #include <random>
 #include <thread>
-#include "dropping_packet_queue.hh"
+#include "abstract_dualpi2_packet_queue.hh"
 
 /*
    Classic queue implementation as part of the DualPI2 implentation described in RFC 9332.
 */
 
-class CLASSICPacketQueue : public DroppingPacketQueue
+class CLASSICPacketQueue : public AbstractDualPI2PacketQueue
 {
 private:
-    //This constant is copied from link_queue.hh.
-    //It maybe better to get this in a more reliable way in the future.
-    const static unsigned int PACKET_SIZE = 1504; /* default max TUN payload size */
-
-
-
 
     virtual const std::string & type( void ) const override
     {
@@ -37,6 +31,7 @@ public:
     void enqueue( QueuedPacket && p ) override;
 
     QueuedPacket dequeue( void ) override;
+   
 };
 
 #endif /* CLASSIC_PACKET_QUEUE_HH */

--- a/src/packet/classic_packet_queue.hh
+++ b/src/packet/classic_packet_queue.hh
@@ -21,16 +21,8 @@ private:
         return type_;
     }
 
-    bool drop_early ( void );
-
-    void calculate_drop_prob ( void );
-
 public:
     CLASSICPacketQueue( const std::string & args );
-
-    void enqueue( QueuedPacket && p ) override;
-
-    QueuedPacket dequeue( void ) override;
    
 };
 

--- a/src/packet/dropping_packet_queue.cc
+++ b/src/packet/dropping_packet_queue.cc
@@ -99,6 +99,18 @@ string DroppingPacketQueue::to_string( void ) const
     return ret;
 }
 
+QueuedPacket* DroppingPacketQueue::peek( void ) 
+{
+    if (empty()) return nullptr;
+    return &(internal_queue_.front());
+}
+
+uint64_t DroppingPacketQueue::qdelay_in_ns ( uint64_t ref ) 
+{
+    QueuedPacket* head = peek();
+    return head ? head->sojourn_time_in_ns ( ref ) : 0 ;
+}
+
 unsigned int DroppingPacketQueue::get_arg( const string & args, const string & name )
 {
     auto offset = args.find( name );

--- a/src/packet/dropping_packet_queue.cc
+++ b/src/packet/dropping_packet_queue.cc
@@ -99,16 +99,17 @@ string DroppingPacketQueue::to_string( void ) const
     return ret;
 }
 
-QueuedPacket* DroppingPacketQueue::peek( void ) 
+QueuedPacket& DroppingPacketQueue::peek( void ) 
 {
-    if (empty()) return nullptr;
-    return &(internal_queue_.front());
+    return internal_queue_.front();
 }
 
 uint64_t DroppingPacketQueue::qdelay_in_ns ( uint64_t ref ) 
 {
-    QueuedPacket* head = peek();
-    return head ? head->sojourn_time_in_ns ( ref ) : 0 ;
+    if ( internal_queue_.empty() ) return 0;
+    
+    QueuedPacket& head = peek();
+    return head.sojourn_time_in_ns( ref );
 }
 
 unsigned int DroppingPacketQueue::get_arg( const string & args, const string & name )

--- a/src/packet/dropping_packet_queue.cc
+++ b/src/packet/dropping_packet_queue.cc
@@ -99,19 +99,6 @@ string DroppingPacketQueue::to_string( void ) const
     return ret;
 }
 
-QueuedPacket& DroppingPacketQueue::peek( void ) 
-{
-    return internal_queue_.front();
-}
-
-uint64_t DroppingPacketQueue::qdelay_in_ns ( uint64_t ref ) 
-{
-    if ( internal_queue_.empty() ) return 0;
-    
-    QueuedPacket& head = peek();
-    return head.sojourn_time_in_ns( ref );
-}
-
 unsigned int DroppingPacketQueue::get_arg( const string & args, const string & name )
 {
     auto offset = args.find( name );

--- a/src/packet/dropping_packet_queue.hh
+++ b/src/packet/dropping_packet_queue.hh
@@ -45,6 +45,9 @@ public:
 
     unsigned int size_bytes( void ) const override;
     unsigned int size_packets( void ) const override;
+
+    QueuedPacket* peek ( void );
+    uint64_t qdelay_in_ns ( uint64_t ref );
 };
 
 #endif /* DROPPING_PACKET_QUEUE_HH */ 

--- a/src/packet/dropping_packet_queue.hh
+++ b/src/packet/dropping_packet_queue.hh
@@ -46,7 +46,7 @@ public:
     unsigned int size_bytes( void ) const override;
     unsigned int size_packets( void ) const override;
 
-    QueuedPacket* peek ( void );
+    QueuedPacket& peek ( void );
     uint64_t qdelay_in_ns ( uint64_t ref );
 };
 

--- a/src/packet/dropping_packet_queue.hh
+++ b/src/packet/dropping_packet_queue.hh
@@ -45,9 +45,6 @@ public:
 
     unsigned int size_bytes( void ) const override;
     unsigned int size_packets( void ) const override;
-
-    QueuedPacket& peek ( void );
-    uint64_t qdelay_in_ns ( uint64_t ref );
 };
 
 #endif /* DROPPING_PACKET_QUEUE_HH */ 

--- a/src/packet/dualq_coupled_aqm.cc
+++ b/src/packet/dualq_coupled_aqm.cc
@@ -80,7 +80,7 @@ void DualQCoupledAQM::enqueue( QueuedPacket && p )
     p.enqueue_time = timestamp_ns();
 
     // Packet classifier
-    unsigned char ecn_bits = get_ecn_bits ( std::move( p ) );
+    unsigned char ecn_bits = get_ecn_bits( p );
 
     if (( ecn_bits == IPTOS_ECN_ECT1 ) ||
         ( ecn_bits == IPTOS_ECN_CE )) {
@@ -135,7 +135,7 @@ QueuedPacket DualQCoupledAQM::dequeue( void )
             pkt = classic_queue_.dequeue();       
             
             if ( recur(classic_queue_, p_c_) ) {
-                if ( get_ecn_bits( std::move( pkt ) ) == IPTOS_ECN_NOT_ECT ||
+                if ( get_ecn_bits( pkt ) == IPTOS_ECN_NOT_ECT ||
                     classic_is_overloaded() ) {
                         drop("");
                         continue;
@@ -189,7 +189,7 @@ void DualQCoupledAQM::drop( std::string reason )
          
 }
 
-unsigned char DualQCoupledAQM::get_ecn_bits( QueuedPacket && p )
+unsigned char DualQCoupledAQM::get_ecn_bits( QueuedPacket & p )
 {
     struct iphdr *ip_header = (struct iphdr *) p.contents[4];
     return ( ip_header->tos & IPTOS_ECN_MASK ) ; 

--- a/src/packet/dualq_coupled_aqm.cc
+++ b/src/packet/dualq_coupled_aqm.cc
@@ -1,0 +1,82 @@
+#include <chrono>
+
+#include "dualq_coupled_aqm.hh"
+#include "timestamp.hh"
+
+using namespace std;
+
+DualQCoupledAQM::DualQCoupledAQM( const string & args )
+  : k_ ( 2 ),
+    lq_ ( 0 ),
+    cq_ ( 0 )
+
+{
+
+  /*
+  if ( qdelay_ref_ == 0 || max_burst_ == 0 ) {
+    throw runtime_error( "Missing params:..." );
+  }
+   */
+
+
+}
+
+void DualQCoupledAQM::enqueue( QueuedPacket && p )
+{
+  calculate_drop_prob();
+
+
+  //assert( good() );
+}
+
+QueuedPacket DualQCoupledAQM::dequeue( void )
+{
+    //QueuedPacket ret = std::move( AbstractPacketQueue::dequeue () );
+    QueuedPacket ret (0, 0);
+    //uint32_t now = timestamp();
+
+    // ...
+
+    return ret;
+}
+
+bool DualQCoupledAQM::empty( void ) const
+{
+    return false;
+}
+
+std::string DualQCoupledAQM::to_string( void ) const
+{
+    return "";
+}
+
+unsigned int DualQCoupledAQM::size_bytes( void ) const
+{
+    return 0;
+}
+
+unsigned int DualQCoupledAQM::size_packets( void ) const
+{
+    return 0;
+}
+
+//returns true if packet should be dropped.
+bool DualQCoupledAQM::drop_early ()
+{
+    return false;
+}
+
+void DualQCoupledAQM::calculate_drop_prob( void )
+{
+  // uint64_t now = timestamp();
+
+}
+
+
+
+
+
+
+
+
+

--- a/src/packet/dualq_coupled_aqm.cc
+++ b/src/packet/dualq_coupled_aqm.cc
@@ -37,7 +37,7 @@ DualQCoupledAQM::DualQCoupledAQM( const string & args )
     }
 
     if ( k_ == 0 ) k_ = 2;
-    p_Cmax_ = min( scale_proba( 1/ pow( k_, 2 ) ), MAX_PROB );
+    p_Cmax_ = min( scale_prob( 1/ pow( k_, 2 ) ), MAX_PROB );
     p_Lmax_ = MAX_PROB;
 
     // TODO: adjust the following values!!
@@ -222,14 +222,6 @@ bool DualQCoupledAQM::recur( AbstractDualPI2PacketQueue & queue, uint32_t likeli
 int64_t DualQCoupledAQM::scale_delta( uint64_t val )
 {
     return val / ((1 << ( ALPHA_BETA_GRANULARITY + 1 )) -1) ;
-}
-
-uint32_t DualQCoupledAQM::scale_proba( double prob )
-{
-    if ( prob < 0.0 || prob > 1.0 )
-        throw runtime_error ("Probability out of range! Provided value: " + std::to_string(prob));
-
-    return static_cast<uint32_t> ( prob * MAX_PROB ) ;
 }
 
 void DualQCoupledAQM::set_periodic_update( void ) 

--- a/src/packet/dualq_coupled_aqm.cc
+++ b/src/packet/dualq_coupled_aqm.cc
@@ -1,82 +1,322 @@
-#include <chrono>
+#include <algorithm>
+//#include <iostream>
 
 #include "dualq_coupled_aqm.hh"
 #include "timestamp.hh"
+#include "exception.hh"
+#include "ezio.hh"
+
+#include "abstract_packet_queue.hh"
+
 
 using namespace std;
 
 DualQCoupledAQM::DualQCoupledAQM( const string & args )
-  : k_ ( 2 ),
-    lq_ ( 0 ),
-    cq_ ( 0 )
-
+  : byte_limit_( get_arg( args, "bytes" ) ),
+    k_ ( get_arg( args, "k" ) ),
+    l4s_queue_ ( L4SPacketQueue ( args ) ),
+    classic_queue_ ( CLASSICPacketQueue ( args ) ),
+    scheduler_type_ ( static_cast<SchedulerType> (get_arg( args, "sched" ))),
+    target_ns_ ( get_arg( args, "target" ) * 1000000 ),
+    max_rtt_ms_ ( get_arg( args, "max_rtt" ) ),
+    alpha_ ( get_arg( args, "alpha" ) ),
+    beta_ ( get_arg( args, "beta" ) ),
+    t_update_ms_ ( get_arg( args, "tupdate" )  ),
+    satur_drop_pkts_ ( 0 ),
+    pp_ ( 0 ),
+    pp_l_ ( 0 ),
+    p_l_ ( 0 ),
+    p_cl_ ( 0 ),
+    p_c_ ( 0 ),
+    p_Cmax_ ( 0 ),
+    l4s_drop_on_overload_ ( true )
 {
+    if ( byte_limit_ == 0 ) {
+        throw runtime_error( "DualPI2 must have a byte limit." );
+    }
 
-  /*
-  if ( qdelay_ref_ == 0 || max_burst_ == 0 ) {
-    throw runtime_error( "Missing params:..." );
-  }
-   */
+    if ( k_ == 0 ) k_ = 2;
+    p_Cmax_ = min(scale_proba( 1/ pow( k_, 2 ) ), MAX_PROB);
+    p_Lmax_ = MAX_PROB;
 
+    // TODO: adjust the following values!!
 
+    if ( target_ns_ == 0 ) target_ns_ = 15000000; 
+    if ( max_rtt_ms_ == 0 ) max_rtt_ms_ = 100;
+    if ( alpha_ == 0 ) alpha_ = 100;
+    if ( beta_ == 0 ) beta_ = 200;
+    if ( t_update_ms_ == 0 ) t_update_ms_ = 16;
+
+    if (scheduler_type_ == SchedulerType::NONE || scheduler_type_ == SchedulerType::WRR) {
+        scheduler_ = std::unique_ptr<WRRScheduler>( new WRRScheduler(l4s_queue_, classic_queue_) );
+    }
+
+    l4s_qdelay_ns_ = 0;
+    classic_qdelay_ns_ = 0;
+
+    /* initialize base timestamp value */
+    initial_timestamp_ns();
+
+    using clock = chrono::steady_clock;
+    uint64_t now = timestamp_ns();
+
+    
+    /* Start the periodic process that updates probs*/
+    //periodic_worker_ = std::thread ( &DualQCoupledAQM::periodic_update, this );
 }
 
 void DualQCoupledAQM::enqueue( QueuedPacket && p )
 {
-  calculate_drop_prob();
+    // 1 MTU of space is always allowed (assumed size of the arriving packet) 
+    // to avoid bias against larger packets. Might end up causing 
+    // underutilization of buffer space...
+    // Use p.contents.size() instead of MTU to be more precise
 
+    if ( size_bytes() + MTU > byte_limit_) {
+        drop ("saturation");
+        return;
+    }
 
-  //assert( good() );
+    // Record the packet's timestamp to calculate the sojourn time. 
+    // Here, I am using the existing p.arrival_time, similar to CoDel.
+
+    // Packet classifier
+    unsigned char ecn_bits = get_ecn_bits ( std::move( p ) );
+
+    if (( ecn_bits == IPTOS_ECN_ECT1 ) ||
+        ( ecn_bits == IPTOS_ECN_CE )) {
+
+        l4s_queue_.enqueue ( std::move( p ) );
+
+    } else {
+        classic_queue_.enqueue ( std::move( p ) );
+    }
+    
 }
 
 QueuedPacket DualQCoupledAQM::dequeue( void )
 {
-    //QueuedPacket ret = std::move( AbstractPacketQueue::dequeue () );
-    QueuedPacket ret (0, 0);
-    //uint32_t now = timestamp();
+    QueuedPacket pkt ("empty", 0);
 
-    // ...
+    // TODO: if both queues are empty, call dualpi2_reset_c_protection
 
-    return ret;
+    while ( size_bytes() > 0 ) {
+        QueueType dequeue_from = scheduler_->select_queue();
+        if ( dequeue_from == QueueType::L4S ) {
+            pkt = l4s_queue_.dequeue ();
+            
+            if ( not l4s_is_overloaded() ) {
+                // pp_, pp_l, p_c_ and p_cl calculated in the periodic update function
+                // TODO: check periodic_update call!
+
+                p_l_ = max (pp_l_, p_cl_);
+
+                if ( recur(l4s_queue_, p_l_) ) {
+                    mark(pkt);
+                 }                      
+            } else {
+                if ( recur(l4s_queue_, p_c_) ) {
+                    drop("saturation");
+                    continue;
+                 } 
+                
+                if ( recur(l4s_queue_, p_cl_) ) {
+                    mark(pkt);
+                 } 
+
+            }
+        } 
+        else if ( dequeue_from == QueueType::Classic) { 
+            pkt = classic_queue_.dequeue ();       
+            
+            if ( recur(classic_queue_, p_c_) ) {
+                if (get_ecn_bits ( std::move( pkt ) ) == IPTOS_ECN_NOT_ECT ||
+                    classic_is_overloaded() ) {
+                        drop ("");
+                        continue;
+                }
+                mark( pkt );
+            }
+        }
+
+        // Apply the WRR credit change 
+        if (scheduler_type_ == SchedulerType::WRR)
+            dynamic_cast<WRRScheduler*>(scheduler_.get())->apply_credit_change();
+
+        return pkt;
+    }
 }
 
 bool DualQCoupledAQM::empty( void ) const
 {
-    return false;
+    return true;
 }
 
 std::string DualQCoupledAQM::to_string( void ) const
 {
-    return "";
+    return "dualPI2";
 }
 
 unsigned int DualQCoupledAQM::size_bytes( void ) const
 {
-    return 0;
+    return l4s_queue_.size_bytes() + classic_queue_.size_bytes();
 }
 
 unsigned int DualQCoupledAQM::size_packets( void ) const
 {
-    return 0;
+    return l4s_queue_.size_packets() + classic_queue_.size_packets();;
 }
 
-//returns true if packet should be dropped.
-bool DualQCoupledAQM::drop_early ()
+void DualQCoupledAQM::drop ( std::string reason )
 {
+    if ( reason == "saturation") {
+        satur_drop_pkts_++;
+    } else if ( reason == "") {
+
+    }
+         
+}
+
+unsigned char DualQCoupledAQM::get_ecn_bits ( QueuedPacket && p )
+{
+    struct iphdr *ip_header = (struct iphdr *) p.contents[4];
+    return ( ip_header->tos & IPTOS_ECN_MASK ) ; 
+}
+
+void DualQCoupledAQM::mark ( QueuedPacket & p )
+{
+    struct iphdr *ip_header = (struct iphdr *) p.contents[4];
+    ip_header->tos = ( ip_header->tos & ~IPTOS_ECN_MASK ) |
+        ( IPTOS_ECN_CE & IPTOS_ECN_MASK );
+
+    // TODO: Recalculate the checksum!! 
+    // See IP_ECN_set_ce in sch_dualpi2_upstream/include/net/inet_ecn.h
+
+}
+
+ /* Returns TRUE with a certain likelihood modeling a recurring (and deterministic) 
+    pattern of marks/drops */ 
+bool DualQCoupledAQM::recur( AbstractDualPI2PacketQueue & queue, uint32_t likelihood )
+{
+    uint32_t count = queue.get_recur_count() + likelihood;
+    if ( count > 1) {
+        queue.set_recur_count ( count - 1 );
+        return true;
+    }
+    queue.set_recur_count ( count );
     return false;
 }
 
-void DualQCoupledAQM::calculate_drop_prob( void )
+int64_t DualQCoupledAQM::scale_delta ( uint64_t val )
 {
-  // uint64_t now = timestamp();
-
+    return val / ((1 << ( ALPHA_BETA_GRANULARITY + 1 )) -1) ;
 }
 
+uint32_t DualQCoupledAQM::scale_proba ( double prob )
+{
+    if ( prob < 0.0 || prob > 1.0 )
+        throw runtime_error ("Probability out of range! Provided value: " + std::to_string(prob));
 
+    return static_cast<uint32_t> (prob * MAX_PROB) ;
+}
 
+void DualQCoupledAQM::periodic_update ( void ) 
+{
+    using clock = chrono::steady_clock;
+    uint64_t now = timestamp_ns();
 
+    uint64_t l4s_qdelay_ns;
 
+    while (update_running_) {
+        pp_ = calculate_base_aqm_prob ( now );
 
+        l4s_qdelay_ns = l4s_queue_.qdelay_in_ns ( now );
+        pp_l_ = l4s_queue_.calculate_l4s_native_prob ( l4s_qdelay_ns ); 
 
+        p_c_ = pow( pp_, 2 );
+        p_cl_ = pp_ * k_ ;
 
+        this_thread::sleep_until ( clock::now () + chrono::milliseconds(t_update_ms_) );
+    }
+    
+}
 
+uint32_t DualQCoupledAQM::calculate_base_aqm_prob ( uint64_t ref ) 
+{
+    /* From  RFC 9332   : dualpi2_update function
+             Linux code : calculate_probability function  */
+
+    uint64_t qdelay_old = max ( l4s_qdelay_ns_, classic_qdelay_ns_ ) ;
+
+    uint32_t new_prob;
+
+    // Update the qdelays
+    l4s_qdelay_ns_ = l4s_queue_.qdelay_in_ns ( ref );
+    classic_qdelay_ns_ = classic_queue_.qdelay_in_ns ( ref );
+
+    uint64_t qdelay = max ( l4s_qdelay_ns_, classic_qdelay_ns_ ) ;
+
+    int64_t delta = ( (int64_t)qdelay - target_ns_ ) * alpha_;
+    delta += ( (int64_t)qdelay - qdelay_old ) * beta_;
+
+    if ( delta > 0 ) {
+        // prevent overflow
+        new_prob = scale_delta( delta ) + pp_ ;
+        if ( new_prob < pp_ )
+            new_prob = MAX_PROB;
+    }
+    else {
+        // prevent underflow
+        new_prob = pp_ - scale_delta( delta * -1 );
+        if ( new_prob > pp_ )
+            new_prob = 0;
+    }
+
+    // TODO: check the capping of p' if no drop on overload
+
+    return new_prob;
+}
+
+unsigned int DualQCoupledAQM::get_arg( const string & args, const string & name )
+{
+    auto offset = args.find( name );
+    if ( offset == string::npos ) {
+        return 0; /* default value */
+    } else {
+        /* extract the value */
+
+        /* advance by length of name */
+        offset += name.size();
+
+        /* make sure next char is "=" */
+        if ( args.substr( offset, 1 ) != "=" ) {
+            throw runtime_error( "could not parse queue arguments: " + args );
+        }
+
+        /* advance by length of "=" */
+        offset++;
+
+        /* find the first non-digit character */
+        auto offset2 = args.substr( offset ).find_first_not_of( "0123456789" );
+
+        auto digit_string = args.substr( offset ).substr( 0, offset2 );
+
+        if ( digit_string.empty() ) {
+            throw runtime_error( "could not parse queue arguments: " + args );
+        }
+      
+        return myatoi( digit_string );
+    }
+}
+
+DualQCoupledAQM::~DualQCoupledAQM ( void )
+{
+    update_running_ = false;
+
+    // if (periodic_worker_.joinable()) {
+    //     periodic_worker_.join();
+    // }
+    
+
+    // TODO: make sure there's resource freeing in case of interrupt
+}

--- a/src/packet/dualq_coupled_aqm.cc
+++ b/src/packet/dualq_coupled_aqm.cc
@@ -77,7 +77,7 @@ void DualQCoupledAQM::enqueue( QueuedPacket && p )
     }
 
     // Record the packet's timestamp to calculate the sojourn time. 
-    // Here, I am using the existing p.arrival_time, similar to CoDel.
+    p.enqueue_time = timestamp_ns();
 
     // Packet classifier
     unsigned char ecn_bits = get_ecn_bits ( std::move( p ) );

--- a/src/packet/dualq_coupled_aqm.cc
+++ b/src/packet/dualq_coupled_aqm.cc
@@ -151,16 +151,25 @@ QueuedPacket DualQCoupledAQM::dequeue( void )
                 p_l_ = max(pp_l_, p_cl_);
 
                 if ( recur(l4s_queue_, p_l_) ) {
-                    mark(pkt);
+                    if ( can_mark_or_drop() )
+                    {
+                        mark( pkt );
+                    }
                 }                      
             } else {
                 if ( recur(l4s_queue_, p_c_) ) {
-                    drop("saturation");
-                    continue;
+                    if ( can_mark_or_drop() ) 
+                    {
+                        drop("saturation");
+                        continue;
+                    }
                 } 
                 
                 if ( recur( l4s_queue_, p_cl_ ) ) {
-                    mark( pkt );
+                    if ( can_mark_or_drop() )
+                    {
+                        mark( pkt );
+                    }
                 } 
             }
             scheduler_update();
@@ -172,12 +181,18 @@ QueuedPacket DualQCoupledAQM::dequeue( void )
             if ( recur(classic_queue_, p_c_) ) {
                 if ( get_ecn_bits( pkt ) == IPTOS_ECN_NOT_ECT ||
                     classic_is_overloaded() ) {
-                        std::cout << " ---- DROPPING !! " << std::endl;
-                        drop("");
-                        continue;
+                        if ( can_mark_or_drop() )
+                        {
+                            std::cout << " ---- DROPPING !! " << std::endl;
+                            drop("");
+                            continue;
+                        }
                 }
-                std::cout << " ---- MARKING !! " << std::endl;
-                mark( pkt );
+                if ( can_mark_or_drop() )
+                {
+                    std::cout << " ---- MARKING !! " << std::endl;
+                    mark( pkt );
+                }
             }
             scheduler_update();
         }
@@ -219,6 +234,14 @@ unsigned int DualQCoupledAQM::size_bytes( void ) const
 unsigned int DualQCoupledAQM::size_packets( void ) const
 {
     return l4s_queue_.size_packets() + classic_queue_.size_packets();;
+}
+
+bool DualQCoupledAQM::can_mark_or_drop( void )
+{
+    if ( size_bytes() < 2 * MTU )
+        return false;
+    
+    return true;
 }
 
 void DualQCoupledAQM::drop( std::string reason )

--- a/src/packet/dualq_coupled_aqm.cc
+++ b/src/packet/dualq_coupled_aqm.cc
@@ -30,11 +30,9 @@ DualQCoupledAQM::DualQCoupledAQM( const string & args )
     p_l_ ( 0 ),
     p_cl_ ( 0 ),
     p_c_ ( 0 ),
-    p_Cmax_ ( 0 ),
     k_ ( 2 ),
     l4s_drop_on_overload_ ( true )
 {
-    std::cout << "packet_limit_= " << std::to_string(packet_limit_) << " byte_limit_= " << std::to_string(byte_limit_);
     if ( packet_limit_ == 0 and byte_limit_ == 0 ) {
         packet_limit_ = 10000; /* default value from Linux code. Represents 125 ms at 1 Gbps */
         byte_limit_ = packet_limit_ * MTU;
@@ -76,9 +74,8 @@ DualQCoupledAQM::DualQCoupledAQM( const string & args )
     /* Start the periodic process that updates probs*/
     set_periodic_update ();
 
-    //poller_.poll( 0 );
-
-    std::cout << "end of the ctor ";
+    std::cout << "end of the ctor " << std::endl;
+    std::cout << "packet_limit_= " << std::to_string(packet_limit_) << " byte_limit_= " << std::to_string(byte_limit_) << std::endl;
 }
 
 void DualQCoupledAQM::enqueue( QueuedPacket && p )
@@ -88,7 +85,13 @@ void DualQCoupledAQM::enqueue( QueuedPacket && p )
     // underutilization of buffer space...
     // Use p.contents.size() instead of MTU to be more precise
 
+    std::cout << "--In DualQCoupled AQM enqueue" << std::endl;
+
+    // check if the periodic update function is due, return immediately if not.
+    poller_.poll( 0 );
+
     if ( size_bytes() + MTU > byte_limit_) {
+        std::cout << "> Drop due to saturation!! " << std::endl;
         drop ("saturation");
         return;
     }
@@ -99,19 +102,26 @@ void DualQCoupledAQM::enqueue( QueuedPacket && p )
     // Packet classifier
     unsigned char ecn_bits = get_ecn_bits( p );
 
+    std::cout << "> ECN bits: " << std::to_string(ecn_bits) << std::endl;
+
     if (( ecn_bits == IPTOS_ECN_ECT1 ) ||
         ( ecn_bits == IPTOS_ECN_CE )) {
-
+            //std::cout << "> Calling L4S enqueue... " << std::endl;
         l4s_queue_.enqueue( std::move( p ) );
 
     } else {
+        //std::cout << "> Calling Classic enqueue... " << std::endl;
         classic_queue_.enqueue( std::move( p ) );
     }
     
+    // check if the periodic update function is due, return immediately if not.
+    poller_.poll( 0 );
 }
 
 QueuedPacket DualQCoupledAQM::dequeue( void )
 {
+    std::cout << "--In DualQCoupled AQM dequeue" << std::endl;
+
     QueueType dequeue_from;
     uint64_t l4s_qdelay_ns;
     uint64_t now;
@@ -123,6 +133,7 @@ QueuedPacket DualQCoupledAQM::dequeue( void )
         QueuedPacket pkt("empty", 0);
         dequeue_from = scheduler_->select_queue();
         if ( dequeue_from == QueueType::L4S ) {
+            std::cout << "> Scheduler selects L4S..." << std::endl;
             pkt = l4s_queue_.dequeue();
             
             if ( not l4s_is_overloaded() ) {
@@ -149,18 +160,26 @@ QueuedPacket DualQCoupledAQM::dequeue( void )
             scheduler_update();
         } 
         else if ( dequeue_from == QueueType::Classic ) { 
+            std::cout << "> Scheduler selects Classic..." << std::endl;
             pkt = classic_queue_.dequeue();       
             
+            std::cout << " ---- Checking P_Cmax = " << p_Cmax_ << std::endl;
             if ( recur(classic_queue_, p_c_) ) {
                 if ( get_ecn_bits( pkt ) == IPTOS_ECN_NOT_ECT ||
                     classic_is_overloaded() ) {
+                        std::cout << " ---- DROPPING !! " << std::endl;
                         drop("");
                         continue;
                 }
+                std::cout << " ---- MARKING !! " << std::endl;
                 mark( pkt );
             }
             scheduler_update();
         }
+
+        // check if the periodic update function is due, return immediately if not.
+        poller_.poll( 0 );
+
         return pkt;
 
     } while ( dequeue_from != QueueType::NONE );
@@ -178,7 +197,7 @@ void DualQCoupledAQM::scheduler_update( void )
 
 bool DualQCoupledAQM::empty( void ) const
 {
-    return true;
+    return l4s_queue_.empty() && classic_queue_.empty();
 }
 
 std::string DualQCoupledAQM::to_string( void ) const
@@ -227,8 +246,13 @@ void DualQCoupledAQM::mark( QueuedPacket & p )
     pattern of marks/drops */ 
 bool DualQCoupledAQM::recur( AbstractDualPI2PacketQueue & queue, uint32_t likelihood )
 {
-    uint32_t count = queue.get_recur_count() + likelihood;
+    std::cout << "##### In recur !!" << std::endl;
+
+    uint64_t count = queue.get_recur_count() + likelihood;
+
+    std::cout << "##### The new count = " << count << std::endl;
     if ( count > MAX_PROB) {
+        std::cout << "##### Count is higer than MAX_PROB. New count is: " << count - MAX_PROB << std::endl;
         queue.set_recur_count( count - MAX_PROB );
         return true;
     }
@@ -244,7 +268,7 @@ int64_t DualQCoupledAQM::scale_delta( uint64_t val )
 uint32_t DualQCoupledAQM::scale_alpha_beta( uint32_t val )
 {
     uint64_t tmp = ((uint64_t)val * MAX_PROB << ALPHA_BETA_SCALING);
-    std::cout << "IN scale alpha beta, val to return is " << std::to_string(tmp / NS_PER_S);
+    std::cout << "IN scale alpha beta, val to return is " << std::to_string(tmp / NS_PER_S) << std::endl;
 
     return tmp / NS_PER_S;
 }
@@ -259,23 +283,39 @@ void DualQCoupledAQM::set_periodic_update( void )
                                             cout << "set_periodic_update function called! " << endl;
 
                                             string str = timer_.read();
-                                            //cout << "Timer read output " << str << endl;
+                                            std::cout << " ------ Timer read output " << std::endl;
 
                                             uint64_t now = timestamp_ns();
                                             pp_ = calculate_base_aqm_prob ( now );
                                             p_c_ = pow( pp_, 2 );
                                             p_cl_ = pp_ * k_ ;
 
+                                            cout << "-- Updated Probs -- " << endl;
+                                            cout << "pp =  " << std::to_string(pp_) << endl;
+                                            cout << "p_c =  " << std::to_string(p_c_) << endl;
+                                            cout << "p_cl =  " << std::to_string(p_cl_) << endl;
+
                                             return ResultType::Continue;
                                         } ) ); 
 }
+
+// void DualQCoupledAQM::print_state( void )
+// {
+//     cout << "function called! " << endl;
+
+// }
 
 uint32_t DualQCoupledAQM::calculate_base_aqm_prob( uint64_t ref ) 
 {
     /* From  RFC 9332   : dualpi2_update function
              Linux code : calculate_probability function  */
 
+    cout << "-- In calculate_base_aqm_prob (that outputs pp) " << endl;
+
     uint64_t qdelay_old = max( l4s_qdelay_ns_, classic_qdelay_ns_ ) ;
+
+    cout << ">> l4s_qdelay_ns = " << std::to_string(l4s_qdelay_ns_) << endl;
+    cout << ">> classic_qdelay_ns = " << std::to_string(classic_qdelay_ns_) << endl;
 
     uint32_t new_prob;
 

--- a/src/packet/dualq_coupled_aqm.cc
+++ b/src/packet/dualq_coupled_aqm.cc
@@ -19,7 +19,7 @@ DualQCoupledAQM::DualQCoupledAQM( const string & args )
     l4s_queue_ ( L4SPacketQueue ( "" ) ),
     classic_queue_ ( CLASSICPacketQueue ( "" ) ),
     scheduler_type_ ( static_cast<SchedulerType> (get_arg( args, "sched" ))),
-    target_ns_ ( get_arg( args, "target" ) * NS_PER_MS ),
+    target_ms_ ( get_arg( args, "target" ) ),
     max_rtt_ms_ ( get_arg( args, "max_rtt" ) ),
     alpha_ ( get_arg( args, "alpha" ) ),
     beta_ ( get_arg( args, "beta" ) ),
@@ -50,7 +50,7 @@ DualQCoupledAQM::DualQCoupledAQM( const string & args )
     p_Cmax_ = min( scale_prob( 1/ pow( k_, 2 ) ), MAX_PROB );
     p_Lmax_ = MAX_PROB;
 
-    if ( target_ns_ == 0 ) target_ns_ = 15 * NS_PER_MS; 
+    if ( target_ms_ == 0 ) target_ms_ = 15; 
     if ( max_rtt_ms_ == 0 ) max_rtt_ms_ = 100;
     if ( t_update_ms_ == 0 ) t_update_ms_ = 16; // RFC 9332: Tupdate = min(target, RTT_max/3)
     
@@ -65,11 +65,11 @@ DualQCoupledAQM::DualQCoupledAQM( const string & args )
         scheduler_ = std::unique_ptr<WRRScheduler>( new WRRScheduler(l4s_queue_, classic_queue_) );
     }
 
-    l4s_qdelay_ns_ = 0;
-    classic_qdelay_ns_ = 0;
+    l4s_qdelay_ms_ = 0;
+    classic_qdelay_ms_ = 0;
 
     /* initialize base timestamp value */
-    initial_timestamp_ns();
+    //initial_timestamp_ns();
 
     /* Start the periodic process that updates probs*/
     set_periodic_update ();
@@ -123,7 +123,7 @@ QueuedPacket DualQCoupledAQM::dequeue( void )
     std::cout << "--In DualQCoupled AQM dequeue" << std::endl;
 
     QueueType dequeue_from;
-    uint64_t l4s_qdelay_ns;
+    uint64_t l4s_qdelay_ms;
     uint64_t now;
 
     // check if the periodic update function is due, return immediately if not.
@@ -137,10 +137,10 @@ QueuedPacket DualQCoupledAQM::dequeue( void )
             pkt = l4s_queue_.dequeue();
             
             if ( not l4s_is_overloaded() ) {
-                now = timestamp_ns();
+                now = timestamp();
 
-                l4s_qdelay_ns = l4s_queue_.qdelay_in_ns( now );
-                pp_l_ = l4s_queue_.calculate_l4s_native_prob( l4s_qdelay_ns ); 
+                l4s_qdelay_ms = l4s_queue_.qdelay_in_ms( now );
+                pp_l_ = l4s_queue_.calculate_l4s_native_prob( l4s_qdelay_ms ); 
 
                 p_l_ = max(pp_l_, p_cl_);
 
@@ -285,7 +285,7 @@ void DualQCoupledAQM::set_periodic_update( void )
                                             string str = timer_.read();
                                             std::cout << " ------ Timer read output " << std::endl;
 
-                                            uint64_t now = timestamp_ns();
+                                            uint64_t now = timestamp();
                                             pp_ = calculate_base_aqm_prob ( now );
                                             p_c_ = pow( pp_, 2 );
                                             p_cl_ = pp_ * k_ ;
@@ -312,20 +312,20 @@ uint32_t DualQCoupledAQM::calculate_base_aqm_prob( uint64_t ref )
 
     cout << "-- In calculate_base_aqm_prob (that outputs pp) " << endl;
 
-    uint64_t qdelay_old = max( l4s_qdelay_ns_, classic_qdelay_ns_ ) ;
+    uint64_t qdelay_old = max( l4s_qdelay_ms_, classic_qdelay_ms_ ) ;
 
-    cout << ">> l4s_qdelay_ns = " << std::to_string(l4s_qdelay_ns_) << endl;
-    cout << ">> classic_qdelay_ns = " << std::to_string(classic_qdelay_ns_) << endl;
+    cout << ">> l4s_qdelay_ms = " << std::to_string(l4s_qdelay_ms_) << endl;
+    cout << ">> classic_qdelay_ms = " << std::to_string(classic_qdelay_ms_) << endl;
 
     uint32_t new_prob;
 
     // Update the qdelays
-    l4s_qdelay_ns_ = l4s_queue_.qdelay_in_ns( ref );
-    classic_qdelay_ns_ = classic_queue_.qdelay_in_ns( ref );
+    l4s_qdelay_ms_ = l4s_queue_.qdelay_in_ms( ref );
+    classic_qdelay_ms_ = classic_queue_.qdelay_in_ms( ref );
 
-    uint64_t qdelay = max( l4s_qdelay_ns_, classic_qdelay_ns_ ) ;
+    uint64_t qdelay = max( l4s_qdelay_ms_, classic_qdelay_ms_ ) ;
 
-    int64_t delta = ( (int64_t)qdelay - target_ns_ ) * alpha_;
+    int64_t delta = ( (int64_t)qdelay - target_ms_ ) * alpha_;
     delta += ( (int64_t)qdelay - qdelay_old ) * beta_;
 
     if ( delta > 0 ) {

--- a/src/packet/dualq_coupled_aqm.cc
+++ b/src/packet/dualq_coupled_aqm.cc
@@ -15,9 +15,9 @@ using namespace PollerShortNames;
 DualQCoupledAQM::DualQCoupledAQM( const string & args )
   : byte_limit_( get_arg( args, "bytes" ) ),
     packet_limit_( get_arg( args, "packets" ) ),
-    k_ ( get_arg( args, "k" ) ),
-    l4s_queue_ ( L4SPacketQueue ( args ) ),
-    classic_queue_ ( CLASSICPacketQueue ( args ) ),
+    //k_ ( get_arg( args, "k" ) ),
+    l4s_queue_ ( L4SPacketQueue ( "" ) ),
+    classic_queue_ ( CLASSICPacketQueue ( "" ) ),
     scheduler_type_ ( static_cast<SchedulerType> (get_arg( args, "sched" ))),
     target_ns_ ( get_arg( args, "target" ) * NS_PER_MS ),
     max_rtt_ms_ ( get_arg( args, "max_rtt" ) ),
@@ -31,8 +31,10 @@ DualQCoupledAQM::DualQCoupledAQM( const string & args )
     p_cl_ ( 0 ),
     p_c_ ( 0 ),
     p_Cmax_ ( 0 ),
+    k_ ( 2 ),
     l4s_drop_on_overload_ ( true )
 {
+    std::cout << "packet_limit_= " << std::to_string(packet_limit_) << " byte_limit_= " << std::to_string(byte_limit_);
     if ( packet_limit_ == 0 and byte_limit_ == 0 ) {
         packet_limit_ = 10000; /* default value from Linux code. Represents 125 ms at 1 Gbps */
         byte_limit_ = packet_limit_ * MTU;
@@ -46,7 +48,7 @@ DualQCoupledAQM::DualQCoupledAQM( const string & args )
         packet_limit_ = byte_limit_ / MTU;
     }
 
-    if ( k_ == 0 ) k_ = 2;
+    //if ( k_ == 0 ) k_ = 2;
     p_Cmax_ = min( scale_prob( 1/ pow( k_, 2 ) ), MAX_PROB );
     p_Lmax_ = MAX_PROB;
 
@@ -75,6 +77,8 @@ DualQCoupledAQM::DualQCoupledAQM( const string & args )
     set_periodic_update ();
 
     //poller_.poll( 0 );
+
+    std::cout << "end of the ctor ";
 }
 
 void DualQCoupledAQM::enqueue( QueuedPacket && p )
@@ -204,7 +208,7 @@ void DualQCoupledAQM::drop( std::string reason )
 
 unsigned char DualQCoupledAQM::get_ecn_bits( QueuedPacket & p )
 {
-    struct iphdr *ip_header = (struct iphdr *) p.contents[4];
+    struct iphdr *ip_header = (struct iphdr *) &p.contents[4];
     return ( ip_header->tos & IPTOS_ECN_MASK ) ; 
 }
 
@@ -240,6 +244,8 @@ int64_t DualQCoupledAQM::scale_delta( uint64_t val )
 uint32_t DualQCoupledAQM::scale_alpha_beta( uint32_t val )
 {
     uint64_t tmp = ((uint64_t)val * MAX_PROB << ALPHA_BETA_SCALING);
+    std::cout << "IN scale alpha beta, val to return is " << std::to_string(tmp / NS_PER_S);
+
     return tmp / NS_PER_S;
 }
 
@@ -300,37 +306,37 @@ uint32_t DualQCoupledAQM::calculate_base_aqm_prob( uint64_t ref )
     return new_prob;
 }
 
-unsigned int DualQCoupledAQM::get_arg( const string & args, const string & name )
-{
-    auto offset = args.find( name );
-    if ( offset == string::npos ) {
-        return 0; /* default value */
-    } else {
-        /* extract the value */
+// unsigned int DualQCoupledAQM::get_arg( const string & args, const string & name )
+// {
+//     auto offset = args.find( name );
+//     if ( offset == string::npos ) {
+//         return 0; /* default value */
+//     } else {
+//         /* extract the value */
 
-        /* advance by length of name */
-        offset += name.size();
+//         /* advance by length of name */
+//         offset += name.size();
 
-        /* make sure next char is "=" */
-        if ( args.substr( offset, 1 ) != "=" ) {
-            throw runtime_error( "could not parse queue arguments: " + args );
-        }
+//         /* make sure next char is "=" */
+//         if ( args.substr( offset, 1 ) != "=" ) {
+//             throw runtime_error( "could not parse queue arguments: " + args + " name: " + name + "substr: " + args.substr( offset, 1 ));
+//         }
 
-        /* advance by length of "=" */
-        offset++;
+//         /* advance by length of "=" */
+//         offset++;
 
-        /* find the first non-digit character */
-        auto offset2 = args.substr( offset ).find_first_not_of( "0123456789" );
+//         /* find the first non-digit character */
+//         auto offset2 = args.substr( offset ).find_first_not_of( "0123456789" );
 
-        auto digit_string = args.substr( offset ).substr( 0, offset2 );
+//         auto digit_string = args.substr( offset ).substr( 0, offset2 );
 
-        if ( digit_string.empty() ) {
-            throw runtime_error( "could not parse queue arguments: " + args );
-        }
+//         if ( digit_string.empty() ) {
+//             throw runtime_error( "could not parse queue arguments: " + args );
+//         }
       
-        return myatoi( digit_string );
-    }
-}
+//         return myatoi( digit_string );
+//     }
+// }
 
 DualQCoupledAQM::~DualQCoupledAQM ( void )
 {

--- a/src/packet/dualq_coupled_aqm.cc
+++ b/src/packet/dualq_coupled_aqm.cc
@@ -47,8 +47,8 @@ DualQCoupledAQM::DualQCoupledAQM( const string & args )
     }
 
     //if ( k_ == 0 ) k_ = 2;
-    p_Cmax_ = min( scale_prob( 1/ pow( k_, 2 ) ), MAX_PROB );
-    p_Lmax_ = MAX_PROB;
+    p_Cmax_ = min( 1/ pow( k_, 2 ) , 1.0 );
+    p_Lmax_ = 1.0;
 
     if ( target_ms_ == 0 ) target_ms_ = 15; 
     if ( max_rtt_ms_ == 0 ) max_rtt_ms_ = 100;
@@ -57,8 +57,8 @@ DualQCoupledAQM::DualQCoupledAQM( const string & args )
     /* From RFC 9332:
         13:   alpha = 0.1 * Tupdate / RTT_max^2      % PI integral gain in Hz
         14:   beta = 0.3 / RTT_max                   % PI proportional gain in Hz */
-    if ( alpha_ == 0 ) alpha_ = scale_alpha_beta( 41 );
-    if ( beta_ == 0 ) beta_ = scale_alpha_beta( 819 );
+    if ( alpha_ == 0 ) alpha_ = 0.16;
+    if ( beta_ == 0 ) beta_ = 3.2;
     
 
     if (scheduler_type_ == SchedulerType::NONE || scheduler_type_ == SchedulerType::WRR) {
@@ -244,33 +244,20 @@ void DualQCoupledAQM::mark( QueuedPacket & p )
 
  /* Returns TRUE with a certain likelihood modeling a recurring (and deterministic) 
     pattern of marks/drops */ 
-bool DualQCoupledAQM::recur( AbstractDualPI2PacketQueue & queue, uint32_t likelihood )
+bool DualQCoupledAQM::recur( AbstractDualPI2PacketQueue & queue, double likelihood )
 {
     std::cout << "##### In recur !!" << std::endl;
 
     uint64_t count = queue.get_recur_count() + likelihood;
 
     std::cout << "##### The new count = " << count << std::endl;
-    if ( count > MAX_PROB) {
-        std::cout << "##### Count is higer than MAX_PROB. New count is: " << count - MAX_PROB << std::endl;
-        queue.set_recur_count( count - MAX_PROB );
+    if ( count > 1.0 ) {
+        //std::cout << "##### Count is higer than MAX_PROB. New count is: " << count - MAX_PROB << std::endl;
+        queue.set_recur_count( count - 1.0 );
         return true;
     }
     queue.set_recur_count( count );
     return false;
-}
-
-int64_t DualQCoupledAQM::scale_delta( uint64_t val )
-{
-    return val / ((1 << ( ALPHA_BETA_GRANULARITY + 1 )) -1) ;
-}
-
-uint32_t DualQCoupledAQM::scale_alpha_beta( uint32_t val )
-{
-    uint64_t tmp = ((uint64_t)val * MAX_PROB << ALPHA_BETA_SCALING);
-    std::cout << "IN scale alpha beta, val to return is " << std::to_string(tmp / NS_PER_S) << std::endl;
-
-    return tmp / NS_PER_S;
 }
 
 void DualQCoupledAQM::set_periodic_update( void ) 
@@ -305,7 +292,7 @@ void DualQCoupledAQM::set_periodic_update( void )
 
 // }
 
-uint32_t DualQCoupledAQM::calculate_base_aqm_prob( uint64_t ref ) 
+double DualQCoupledAQM::calculate_base_aqm_prob( uint64_t ref ) 
 {
     /* From  RFC 9332   : dualpi2_update function
              Linux code : calculate_probability function  */
@@ -317,7 +304,7 @@ uint32_t DualQCoupledAQM::calculate_base_aqm_prob( uint64_t ref )
     cout << ">> l4s_qdelay_ms = " << std::to_string(l4s_qdelay_ms_) << endl;
     cout << ">> classic_qdelay_ms = " << std::to_string(classic_qdelay_ms_) << endl;
 
-    uint32_t new_prob;
+    
 
     // Update the qdelays
     l4s_qdelay_ms_ = l4s_queue_.qdelay_in_ms( ref );
@@ -325,20 +312,17 @@ uint32_t DualQCoupledAQM::calculate_base_aqm_prob( uint64_t ref )
 
     uint64_t qdelay = max( l4s_qdelay_ms_, classic_qdelay_ms_ ) ;
 
-    int64_t delta = ( (int64_t)qdelay - target_ms_ ) * alpha_;
-    delta += ( (int64_t)qdelay - qdelay_old ) * beta_;
-
-    if ( delta > 0 ) {
+    double new_prob = ((int64_t)qdelay - target_ms_) * alpha_ + ((int64_t)qdelay - qdelay_old) * beta_;
+    
+    if ( new_prob > 1.0 ) {
         // prevent overflow
-        new_prob = scale_delta( delta ) + pp_ ;
-        if ( new_prob < pp_ )
-            new_prob = MAX_PROB;
+            new_prob = 1.0;
     }
-    else {
+    else if ( new_prob < 0.0) {
         // prevent underflow
-        new_prob = pp_ - scale_delta( delta * -1 );
+        //new_prob = pp_ - scale_delta( delta * -1 );
         if ( new_prob > pp_ )
-            new_prob = 0;
+            new_prob = 0.0;
     }
 
     // TODO: check the capping of p' if no drop on overload

--- a/src/packet/dualq_coupled_aqm.cc
+++ b/src/packet/dualq_coupled_aqm.cc
@@ -57,8 +57,10 @@ DualQCoupledAQM::DualQCoupledAQM( const string & args )
     /* From RFC 9332:
         13:   alpha = 0.1 * Tupdate / RTT_max^2      % PI integral gain in Hz
         14:   beta = 0.3 / RTT_max                   % PI proportional gain in Hz */
-    if ( alpha_ == 0 ) alpha_ = 0.16;
-    if ( beta_ == 0 ) beta_ = 3.2;
+    
+    // Since the default time unit is ms, alpha and beta have to be in kHz
+    if ( alpha_ == 0 ) alpha_ = 0.00016;
+    if ( beta_ == 0 ) beta_ = 0.0032;
     
 
     if (scheduler_type_ == SchedulerType::NONE || scheduler_type_ == SchedulerType::WRR) {
@@ -74,8 +76,8 @@ DualQCoupledAQM::DualQCoupledAQM( const string & args )
     /* Start the periodic process that updates probs*/
     set_periodic_update ();
 
-    std::cout << "end of the ctor " << std::endl;
-    std::cout << "packet_limit_= " << std::to_string(packet_limit_) << " byte_limit_= " << std::to_string(byte_limit_) << std::endl;
+    //std::cout << "end of the ctor " << std::endl;
+    //std::cout << "packet_limit_= " << std::to_string(packet_limit_) << " byte_limit_= " << std::to_string(byte_limit_) << std::endl;
 }
 
 void DualQCoupledAQM::enqueue( QueuedPacket && p )
@@ -85,13 +87,13 @@ void DualQCoupledAQM::enqueue( QueuedPacket && p )
     // underutilization of buffer space...
     // Use p.contents.size() instead of MTU to be more precise
 
-    std::cout << "--In DualQCoupled AQM enqueue" << std::endl;
+    //std::cout << "--In DualQCoupled AQM enqueue" << std::endl;
 
     // check if the periodic update function is due, return immediately if not.
     poller_.poll( 0 );
 
     if ( size_bytes() + MTU > byte_limit_) {
-        std::cout << "> Drop due to saturation!! " << std::endl;
+        std::cout << "> Drop due to saturationnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn!! " << std::endl;
         drop ("saturation");
         return;
     }
@@ -102,15 +104,15 @@ void DualQCoupledAQM::enqueue( QueuedPacket && p )
     // Packet classifier
     unsigned char ecn_bits = get_ecn_bits( p );
 
-    std::cout << "> ECN bits: " << std::to_string(ecn_bits) << std::endl;
+    //std::cout << "> ECN bits: " << std::to_string(ecn_bits) << std::endl;
 
     if (( ecn_bits == IPTOS_ECN_ECT1 ) ||
         ( ecn_bits == IPTOS_ECN_CE )) {
-            //std::cout << "> Calling L4S enqueue... " << std::endl;
+            ////std::cout << "> Calling L4S enqueue... " << std::endl;
         l4s_queue_.enqueue( std::move( p ) );
 
     } else {
-        //std::cout << "> Calling Classic enqueue... " << std::endl;
+        std::cout << "> Calling Classic enqueue... " << std::endl;
         classic_queue_.enqueue( std::move( p ) );
     }
     
@@ -120,20 +122,20 @@ void DualQCoupledAQM::enqueue( QueuedPacket && p )
 
 QueuedPacket DualQCoupledAQM::dequeue( void )
 {
-    std::cout << "--In DualQCoupled AQM dequeue" << std::endl;
+    //std::cout << "--In DualQCoupled AQM dequeue" << std::endl;
 
     QueueType dequeue_from;
     uint64_t l4s_qdelay_ms;
     uint64_t now;
 
-    // check if the periodic update function is due, return immediately if not.
-    poller_.poll( 0 );
-
     do {
+        // check if the periodic update function is due, return immediately if not.
+        poller_.poll( 0 );
+
         QueuedPacket pkt("empty", 0);
         dequeue_from = scheduler_->select_queue();
+
         if ( dequeue_from == QueueType::L4S ) {
-            std::cout << "> Scheduler selects L4S..." << std::endl;
             pkt = l4s_queue_.dequeue();
             
             if ( not l4s_is_overloaded() ) {
@@ -163,7 +165,6 @@ QueuedPacket DualQCoupledAQM::dequeue( void )
             std::cout << "> Scheduler selects Classic..." << std::endl;
             pkt = classic_queue_.dequeue();       
             
-            std::cout << " ---- Checking P_Cmax = " << p_Cmax_ << std::endl;
             if ( recur(classic_queue_, p_c_) ) {
                 if ( get_ecn_bits( pkt ) == IPTOS_ECN_NOT_ECT ||
                     classic_is_overloaded() ) {
@@ -246,9 +247,9 @@ void DualQCoupledAQM::mark( QueuedPacket & p )
     pattern of marks/drops */ 
 bool DualQCoupledAQM::recur( AbstractDualPI2PacketQueue & queue, double likelihood )
 {
-    std::cout << "##### In recur !!" << std::endl;
+    std::cout << "##### In recur !! likelihood is " << likelihood << std::endl;
 
-    uint64_t count = queue.get_recur_count() + likelihood;
+    double count = queue.get_recur_count() + likelihood;
 
     std::cout << "##### The new count = " << count << std::endl;
     if ( count > 1.0 ) {
@@ -270,7 +271,7 @@ void DualQCoupledAQM::set_periodic_update( void )
                                             cout << "set_periodic_update function called! " << endl;
 
                                             string str = timer_.read();
-                                            std::cout << " ------ Timer read output " << std::endl;
+                                            std::cout << " ------ Timer read output " << str << std::endl;
 
                                             uint64_t now = timestamp();
                                             pp_ = calculate_base_aqm_prob ( now );
@@ -298,11 +299,14 @@ double DualQCoupledAQM::calculate_base_aqm_prob( uint64_t ref )
              Linux code : calculate_probability function  */
 
     cout << "-- In calculate_base_aqm_prob (that outputs pp) " << endl;
+    
+    cout << ">> alpha = " << std::to_string(alpha_) << endl;
+    cout << ">> beta = " << std::to_string(beta_) << endl;
 
     uint64_t qdelay_old = max( l4s_qdelay_ms_, classic_qdelay_ms_ ) ;
 
-    cout << ">> l4s_qdelay_ms = " << std::to_string(l4s_qdelay_ms_) << endl;
-    cout << ">> classic_qdelay_ms = " << std::to_string(classic_qdelay_ms_) << endl;
+    cout << ">> [old] l4s_qdelay_ms = " << std::to_string(l4s_qdelay_ms_) << endl;
+    cout << ">> [old] classic_qdelay_ms = " << std::to_string(classic_qdelay_ms_) << endl;
 
     
 
@@ -312,17 +316,21 @@ double DualQCoupledAQM::calculate_base_aqm_prob( uint64_t ref )
 
     uint64_t qdelay = max( l4s_qdelay_ms_, classic_qdelay_ms_ ) ;
 
-    double new_prob = ((int64_t)qdelay - target_ms_) * alpha_ + ((int64_t)qdelay - qdelay_old) * beta_;
+    cout << ">> [new] l4s_qdelay_ms = " << std::to_string(l4s_qdelay_ms_) << endl;
+    cout << ">> [new] classic_qdelay_ms = " << std::to_string(classic_qdelay_ms_) << endl;
+
+    double new_prob = (static_cast<double>(qdelay) - target_ms_) * alpha_ 
+                    + (static_cast<double>(qdelay) - qdelay_old) * beta_;
     
+    cout << ">> new_prob = " << std::to_string(new_prob) << endl;
+
     if ( new_prob > 1.0 ) {
         // prevent overflow
-            new_prob = 1.0;
+        new_prob = 1.0;
     }
     else if ( new_prob < 0.0) {
         // prevent underflow
-        //new_prob = pp_ - scale_delta( delta * -1 );
-        if ( new_prob > pp_ )
-            new_prob = 0.0;
+        new_prob = 0.0;
     }
 
     // TODO: check the capping of p' if no drop on overload

--- a/src/packet/dualq_coupled_aqm.cc
+++ b/src/packet/dualq_coupled_aqm.cc
@@ -90,7 +90,7 @@ void DualQCoupledAQM::enqueue( QueuedPacket && p )
     }
 
     // Record the packet's timestamp to calculate the sojourn time. 
-    p.enqueue_time = timestamp_ns();
+    // Here, I am using the existing p.arrival_time, similar to CoDel.
 
     // Packet classifier
     unsigned char ecn_bits = get_ecn_bits( p );

--- a/src/packet/dualq_coupled_aqm.cc
+++ b/src/packet/dualq_coupled_aqm.cc
@@ -90,6 +90,7 @@ void DualQCoupledAQM::enqueue( QueuedPacket && p )
     //std::cout << "--In DualQCoupled AQM enqueue" << std::endl;
 
     // check if the periodic update function is due, return immediately if not.
+    std::cout << "> Polling (start of enqueue)" << std::endl;
     poller_.poll( 0 );
 
     if ( size_bytes() + MTU > byte_limit_) {
@@ -108,7 +109,7 @@ void DualQCoupledAQM::enqueue( QueuedPacket && p )
 
     if (( ecn_bits == IPTOS_ECN_ECT1 ) ||
         ( ecn_bits == IPTOS_ECN_CE )) {
-            ////std::cout << "> Calling L4S enqueue... " << std::endl;
+            std::cout << "> Calling L4S enqueue... " << std::endl;
         l4s_queue_.enqueue( std::move( p ) );
 
     } else {
@@ -117,12 +118,13 @@ void DualQCoupledAQM::enqueue( QueuedPacket && p )
     }
     
     // check if the periodic update function is due, return immediately if not.
+    std::cout << "> Polling (end of enqueue)" << std::endl;
     poller_.poll( 0 );
 }
 
 QueuedPacket DualQCoupledAQM::dequeue( void )
 {
-    //std::cout << "--In DualQCoupled AQM dequeue" << std::endl;
+    std::cout << "--In DualQCoupled AQM dequeue" << std::endl;
 
     QueueType dequeue_from;
     uint64_t l4s_qdelay_ms;
@@ -130,12 +132,14 @@ QueuedPacket DualQCoupledAQM::dequeue( void )
 
     do {
         // check if the periodic update function is due, return immediately if not.
+        std::cout << "> Polling (start of dequeue iteration)" << std::endl;
         poller_.poll( 0 );
 
         QueuedPacket pkt("empty", 0);
         dequeue_from = scheduler_->select_queue();
 
         if ( dequeue_from == QueueType::L4S ) {
+            std::cout << "> Scheduler selects L4S..." << std::endl;
             pkt = l4s_queue_.dequeue();
             
             if ( not l4s_is_overloaded() ) {
@@ -179,6 +183,7 @@ QueuedPacket DualQCoupledAQM::dequeue( void )
         }
 
         // check if the periodic update function is due, return immediately if not.
+        std::cout << "> Polling (end of dequeue iteration)" << std::endl;
         poller_.poll( 0 );
 
         return pkt;
@@ -234,12 +239,20 @@ unsigned char DualQCoupledAQM::get_ecn_bits( QueuedPacket & p )
 
 void DualQCoupledAQM::mark( QueuedPacket & p )
 {
-    struct iphdr *ip_header = (struct iphdr *) p.contents[4];
-    ip_header->tos = ( ip_header->tos & ~IPTOS_ECN_MASK ) |
-        ( IPTOS_ECN_CE & IPTOS_ECN_MASK );
+    std::cout << ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> Mark() called!! " << std::endl;
+    struct iphdr *ip_header = (struct iphdr *) &p.contents[4];
 
-    // TODO: Recalculate the checksum!! 
-    // See IP_ECN_set_ce in sch_dualpi2_upstream/include/net/inet_ecn.h
+    std::cout << "-- Previous tos: " << std::to_string(ip_header->tos) << std::endl;
+    std::cout << "-- Previous Checksum: " << ntohs(ip_header->check) << std::endl;
+
+    ip_header->tos = ( ip_header->tos & ~IPTOS_ECN_MASK ) | ( IPTOS_ECN_CE & IPTOS_ECN_MASK );
+
+    std::cout << "-- New tos: " << std::to_string(ip_header->tos) << std::endl;
+
+    ip_header->check = calculate_ip_checksum ((unsigned short*) ip_header, ip_header->ihl << 2);
+
+    struct iphdr *ip_header2 = (struct iphdr *) &p.contents[4];
+    std::cout << "-- New Checksum: " << ntohs(ip_header->check) << " should be = "<< ntohs(ip_header2->check) << std::endl;
 
 }
 

--- a/src/packet/dualq_coupled_aqm.cc
+++ b/src/packet/dualq_coupled_aqm.cc
@@ -14,6 +14,7 @@ using namespace PollerShortNames;
 
 DualQCoupledAQM::DualQCoupledAQM( const string & args )
   : byte_limit_( get_arg( args, "bytes" ) ),
+    packet_limit_( get_arg( args, "packets" ) ),
     k_ ( get_arg( args, "k" ) ),
     l4s_queue_ ( L4SPacketQueue ( args ) ),
     classic_queue_ ( CLASSICPacketQueue ( args ) ),
@@ -32,21 +33,33 @@ DualQCoupledAQM::DualQCoupledAQM( const string & args )
     p_Cmax_ ( 0 ),
     l4s_drop_on_overload_ ( true )
 {
-    if ( byte_limit_ == 0 ) {
-        throw runtime_error( "DualPI2 must have a byte limit." );
+    if ( packet_limit_ == 0 and byte_limit_ == 0 ) {
+        packet_limit_ = 10000; /* default value from Linux code. Represents 125 ms at 1 Gbps */
+        byte_limit_ = packet_limit_ * MTU;
+    }
+    else if (packet_limit_ != 0) {
+        // Prioritize packet_limit_ over byte_limit_
+        byte_limit_ = packet_limit_ * MTU;
+
+    }
+    else if (byte_limit_ != 0) {
+        packet_limit_ = byte_limit_ / MTU;
     }
 
     if ( k_ == 0 ) k_ = 2;
     p_Cmax_ = min( scale_prob( 1/ pow( k_, 2 ) ), MAX_PROB );
     p_Lmax_ = MAX_PROB;
 
-    // TODO: adjust the following values!!
-
     if ( target_ns_ == 0 ) target_ns_ = 15 * NS_PER_MS; 
     if ( max_rtt_ms_ == 0 ) max_rtt_ms_ = 100;
-    if ( alpha_ == 0 ) alpha_ = 100;
-    if ( beta_ == 0 ) beta_ = 200;
-    if ( t_update_ms_ == 0 ) t_update_ms_ = 16;
+    if ( t_update_ms_ == 0 ) t_update_ms_ = 16; // RFC 9332: Tupdate = min(target, RTT_max/3)
+    
+    /* From RFC 9332:
+        13:   alpha = 0.1 * Tupdate / RTT_max^2      % PI integral gain in Hz
+        14:   beta = 0.3 / RTT_max                   % PI proportional gain in Hz */
+    if ( alpha_ == 0 ) alpha_ = scale_alpha_beta( 41 );
+    if ( beta_ == 0 ) beta_ = scale_alpha_beta( 819 );
+    
 
     if (scheduler_type_ == SchedulerType::NONE || scheduler_type_ == SchedulerType::WRR) {
         scheduler_ = std::unique_ptr<WRRScheduler>( new WRRScheduler(l4s_queue_, classic_queue_) );
@@ -222,6 +235,12 @@ bool DualQCoupledAQM::recur( AbstractDualPI2PacketQueue & queue, uint32_t likeli
 int64_t DualQCoupledAQM::scale_delta( uint64_t val )
 {
     return val / ((1 << ( ALPHA_BETA_GRANULARITY + 1 )) -1) ;
+}
+
+uint32_t DualQCoupledAQM::scale_alpha_beta( uint32_t val )
+{
+    uint64_t tmp = ((uint64_t)val * MAX_PROB << ALPHA_BETA_SCALING);
+    return tmp / NS_PER_S;
 }
 
 void DualQCoupledAQM::set_periodic_update( void ) 

--- a/src/packet/dualq_coupled_aqm.cc
+++ b/src/packet/dualq_coupled_aqm.cc
@@ -224,8 +224,8 @@ void DualQCoupledAQM::mark( QueuedPacket & p )
 bool DualQCoupledAQM::recur( AbstractDualPI2PacketQueue & queue, uint32_t likelihood )
 {
     uint32_t count = queue.get_recur_count() + likelihood;
-    if ( count > 1) {
-        queue.set_recur_count( count - 1 );
+    if ( count > MAX_PROB) {
+        queue.set_recur_count( count - MAX_PROB );
         return true;
     }
     queue.set_recur_count( count );

--- a/src/packet/dualq_coupled_aqm.hh
+++ b/src/packet/dualq_coupled_aqm.hh
@@ -108,6 +108,8 @@ private:
     int64_t scale_delta ( uint64_t val );
     uint32_t scale_proba ( double prob );
 
+    void scheduler_update ( void );
+
 public:
     DualQCoupledAQM( const std::string & args );
 

--- a/src/packet/dualq_coupled_aqm.hh
+++ b/src/packet/dualq_coupled_aqm.hh
@@ -96,19 +96,19 @@ private:
     }
     */
 
-    void drop ( std::string reason );
+    void drop( std::string reason );
 
-    unsigned char get_ecn_bits ( QueuedPacket && p );
+    unsigned char get_ecn_bits( QueuedPacket && p );
 
-    void mark ( QueuedPacket & p );
+    void mark( QueuedPacket & p );
 
-    bool l4s_is_overloaded ( void ) { return p_cl_ >= p_Lmax_; }
+    bool l4s_is_overloaded( void ) { return p_cl_ >= p_Lmax_; }
     bool classic_is_overloaded ( void ) { return p_c_ >= p_Cmax_; }
 
-    int64_t scale_delta ( uint64_t val );
-    uint32_t scale_proba ( double prob );
+    int64_t scale_delta( uint64_t val );
+    uint32_t scale_proba( double prob );
 
-    void scheduler_update ( void );
+    void scheduler_update( void );
 
 public:
     DualQCoupledAQM( const std::string & args );
@@ -127,10 +127,10 @@ public:
 
     bool recur( AbstractDualPI2PacketQueue & queue, uint32_t likelihood );
 
-    void set_periodic_update ( void );
-    uint32_t calculate_base_aqm_prob ( uint64_t ref );
+    void set_periodic_update( void );
+    uint32_t calculate_base_aqm_prob( uint64_t ref );
 
-    ~DualQCoupledAQM ( void );
+    ~DualQCoupledAQM( void );
 };
 
 #endif /* DUALQ_COUPLED_AQM_HH */

--- a/src/packet/dualq_coupled_aqm.hh
+++ b/src/packet/dualq_coupled_aqm.hh
@@ -106,7 +106,6 @@ private:
     bool classic_is_overloaded ( void ) { return p_c_ >= p_Cmax_; }
 
     int64_t scale_delta( uint64_t val );
-    uint32_t scale_proba( double prob );
 
     void scheduler_update( void );
 

--- a/src/packet/dualq_coupled_aqm.hh
+++ b/src/packet/dualq_coupled_aqm.hh
@@ -35,9 +35,6 @@ private:
     //It maybe better to get this in a more reliable way in the future.
     const static unsigned int PACKET_SIZE = 1504; /* default max TUN payload size */
 
-    // default max TUN payload size from link_queue.hh.
-    const static unsigned int MTU = 1504; /*  */
-
     const unsigned int byte_limit_;
 
     // Proportional Integral (PI) controller parameters

--- a/src/packet/dualq_coupled_aqm.hh
+++ b/src/packet/dualq_coupled_aqm.hh
@@ -95,7 +95,7 @@ private:
 
     void drop( std::string reason );
 
-    unsigned char get_ecn_bits( QueuedPacket && p );
+    unsigned char get_ecn_bits( QueuedPacket & p );
 
     void mark( QueuedPacket & p );
 

--- a/src/packet/dualq_coupled_aqm.hh
+++ b/src/packet/dualq_coupled_aqm.hh
@@ -4,12 +4,13 @@
 #define DUALQ_COUPLED_AQM_HH
 
 #include <random>
-#include <thread>
+//#include <thread>
 #include <chrono>
 #include <atomic>
 #include <netinet/ip.h>
 
-#include "timestamp.hh"
+#include "poller.hh"
+#include "timerfd.hh"
 
 #include "abstract_packet_queue.hh"
 #include "l4s_packet_queue.hh"
@@ -21,6 +22,7 @@
 /* Used to scale the delay diff */
 #define ALPHA_BETA_GRANULARITY 6
 
+#define NS_PER_MS 1000000
 
 /*
    DualQ Coupled AQM, Implemented as DualQ PI2 based on RFC 9332.
@@ -43,7 +45,8 @@ private:
     // Trigger update every...    
     uint16_t t_update_ms_;
 
-    std::thread periodic_worker_ ;
+    Poller poller_ ;
+    Timerfd timer_ ;
 
     /* From RFC 9332:
         13:   alpha = 0.1 * Tupdate / RTT_max^2      % PI integral gain in Hz
@@ -122,7 +125,7 @@ public:
 
     bool recur( AbstractDualPI2PacketQueue & queue, uint32_t likelihood );
 
-    void periodic_update ( void );
+    void set_periodic_update ( void );
     uint32_t calculate_base_aqm_prob ( uint64_t ref );
 
     ~DualQCoupledAQM ( void );

--- a/src/packet/dualq_coupled_aqm.hh
+++ b/src/packet/dualq_coupled_aqm.hh
@@ -1,0 +1,62 @@
+/* -*-mode:c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#ifndef DUALQ_COUPLED_AQM_HH
+#define DUALQ_COUPLED_AQM_HH
+
+#include <random>
+#include <thread>
+#include "abstract_packet_queue.hh"
+#include "l4s_packet_queue.hh"
+#include "classic_packet_queue.hh"
+
+/*
+   DualQ Coupled AQM, Implemented as DualQ PI2 based on RFC 9332.
+*/
+
+class DualQCoupledAQM : public AbstractPacketQueue
+{
+private:
+    //This constant is copied from link_queue.hh.
+    //It maybe better to get this in a more reliable way in the future.
+    const static unsigned int PACKET_SIZE = 1504; /* default max TUN payload size */
+
+    uint32_t k_;
+    L4SPacketQueue lq_;
+    CLASSICPacketQueue cq_;
+
+
+    // TODO: Add components of the DualQ AQM
+        // scheduler object
+
+
+    /*
+    virtual const std::string & type( void ) const override
+    {
+        static const std::string type_ { "dualPI2" };
+        return type_;
+    }
+    */
+
+    bool drop_early ( void );
+
+    void calculate_drop_prob ( void );
+
+public:
+    DualQCoupledAQM( const std::string & args );
+
+    void enqueue( QueuedPacket && p ) override;
+
+    QueuedPacket dequeue( void ) override;
+
+    bool empty( void ) const override;
+
+    std::string to_string( void ) const override;
+
+    unsigned int size_bytes( void ) const override;
+
+    unsigned int size_packets( void ) const override;
+};
+
+#endif /* DUALQ_COUPLED_AQM_HH */
+
+

--- a/src/packet/dualq_coupled_aqm.hh
+++ b/src/packet/dualq_coupled_aqm.hh
@@ -50,8 +50,8 @@ private:
     Poller poller_ ;
     Timerfd timer_ ;
 
-    uint32_t alpha_;
-    uint32_t beta_;
+    double alpha_;
+    double beta_;
 
     // Coupling factor
     uint32_t k_;
@@ -73,13 +73,13 @@ private:
 
     uint32_t satur_drop_pkts_;
 
-    uint32_t pp_l_; 
-    uint32_t pp_;
-    uint32_t p_l_;
-    uint32_t p_c_;
-    uint32_t p_cl_;
-    uint32_t p_Cmax_;
-    uint32_t p_Lmax_;
+    double pp_l_; 
+    double pp_;
+    double p_l_;
+    double p_c_;
+    double p_cl_;
+    double p_Cmax_;
+    double p_Lmax_;
 
     bool l4s_drop_on_overload_;
 
@@ -103,9 +103,6 @@ private:
     bool l4s_is_overloaded( void ) { return p_cl_ >= p_Lmax_; }
     bool classic_is_overloaded ( void ) { return p_c_ >= p_Cmax_; }
 
-    int64_t scale_delta( uint64_t val );
-    uint32_t scale_alpha_beta( uint32_t val );
-
     void scheduler_update( void );
 
 public:
@@ -123,10 +120,10 @@ public:
     unsigned int size_bytes( void ) const override;
     unsigned int size_packets( void ) const override;
 
-    bool recur( AbstractDualPI2PacketQueue & queue, uint32_t likelihood );
+    bool recur( AbstractDualPI2PacketQueue & queue, double likelihood );
 
     void set_periodic_update( void );
-    uint32_t calculate_base_aqm_prob( uint64_t ref );
+    double calculate_base_aqm_prob( uint64_t ref );
 
     ~DualQCoupledAQM( void );
 };

--- a/src/packet/dualq_coupled_aqm.hh
+++ b/src/packet/dualq_coupled_aqm.hh
@@ -19,10 +19,14 @@
 #include "abstract_l4s_scheduler.hh"
 #include "weighted_round_robin_scheduler.hh"
 
+#define ALPHA_BETA_SHIFT 8
 /* Used to scale the delay diff */
 #define ALPHA_BETA_GRANULARITY 6
 
+#define ALPHA_BETA_SCALING (ALPHA_BETA_SHIFT - ALPHA_BETA_GRANULARITY)
+
 #define NS_PER_MS 1000000
+#define NS_PER_S  1000000000
 
 /*
    DualQ Coupled AQM, Implemented as DualQ PI2 based on RFC 9332.
@@ -35,7 +39,8 @@ private:
     //It maybe better to get this in a more reliable way in the future.
     const static unsigned int PACKET_SIZE = 1504; /* default max TUN payload size */
 
-    const unsigned int byte_limit_;
+    unsigned int byte_limit_;
+    unsigned int packet_limit_;
 
     // Proportional Integral (PI) controller parameters
 
@@ -44,10 +49,6 @@ private:
 
     Poller poller_ ;
     Timerfd timer_ ;
-
-    /* From RFC 9332:
-        13:   alpha = 0.1 * Tupdate / RTT_max^2      % PI integral gain in Hz
-        14:   beta = 0.3 / RTT_max                   % PI proportional gain in Hz */
 
     uint32_t alpha_;
     uint32_t beta_;
@@ -103,6 +104,7 @@ private:
     bool classic_is_overloaded ( void ) { return p_c_ >= p_Cmax_; }
 
     int64_t scale_delta( uint64_t val );
+    uint32_t scale_alpha_beta( uint32_t val );
 
     void scheduler_update( void );
 

--- a/src/packet/dualq_coupled_aqm.hh
+++ b/src/packet/dualq_coupled_aqm.hh
@@ -94,6 +94,7 @@ private:
     }
     */
 
+    bool can_mark_or_drop( void );
     void drop( std::string reason );
 
     unsigned char get_ecn_bits( QueuedPacket & p );

--- a/src/packet/dualq_coupled_aqm.hh
+++ b/src/packet/dualq_coupled_aqm.hh
@@ -118,7 +118,7 @@ public:
 
     std::string to_string( void ) const override;
 
-    static unsigned int get_arg( const std::string & args, const std::string & name );
+    //static unsigned int get_arg( const std::string & args, const std::string & name );
 
     unsigned int size_bytes( void ) const override;
     unsigned int size_packets( void ) const override;

--- a/src/packet/dualq_coupled_aqm.hh
+++ b/src/packet/dualq_coupled_aqm.hh
@@ -57,10 +57,10 @@ private:
     uint32_t k_;
 
     // Target queue delay
-    uint64_t target_ns_;
+    uint64_t target_ms_;
 
-    uint64_t l4s_qdelay_ns_;
-    uint64_t classic_qdelay_ns_;
+    uint64_t l4s_qdelay_ms_;
+    uint64_t classic_qdelay_ms_;
 
     uint32_t max_rtt_ms_;
 

--- a/src/packet/l4s_packet_queue.cc
+++ b/src/packet/l4s_packet_queue.cc
@@ -1,0 +1,53 @@
+#include <chrono>
+
+#include "l4s_packet_queue.hh"
+#include "timestamp.hh"
+
+using namespace std;
+
+#define DQ_COUNT_INVALID   (uint32_t)-1
+
+L4SPacketQueue::L4SPacketQueue( const string & args )
+  : DroppingPacketQueue(args)
+{
+  /*
+  if ( qdelay_ref_ == 0 || max_burst_ == 0 ) {
+    throw runtime_error( "PIE AQM queue must have qdelay_ref and max_burst parameters" );
+  }
+   */
+}
+
+void L4SPacketQueue::enqueue( QueuedPacket && p )
+{
+  calculate_drop_prob();
+
+
+
+  assert( good() );
+}
+
+//returns true if packet should be dropped.
+bool L4SPacketQueue::drop_early ()
+{
+
+    return false;
+}
+
+QueuedPacket L4SPacketQueue::dequeue( void )
+{
+  QueuedPacket ret = std::move( DroppingPacketQueue::dequeue () );
+  uint32_t now = timestamp();
+
+
+
+  return ret;
+}
+
+void L4SPacketQueue::calculate_drop_prob( void )
+{
+  uint64_t now = timestamp();
+
+
+
+
+}

--- a/src/packet/l4s_packet_queue.cc
+++ b/src/packet/l4s_packet_queue.cc
@@ -51,23 +51,24 @@ uint32_t L4SPacketQueue::calculate_l4s_native_prob ( uint64_t qdelay )
         // Do not mark packets if under min_qlen_pkt_ (default is 1)
         return 0;
 
-    if ( step_ ) {
-        if ( qdelay >= max_delay_thresh_us_ ) {
-            return 1;
+    // In both the step and the ramp methods:
+    if ( qdelay >= max_delay_thresh_us_ ) {
+            return MAX_PROB;
         }
+
+    // Here, qdelay < max_delay_thresh_us_
+    
+    if ( step_ ) {
         return 0;
     }
     else {
         // Use a ramp function: 'laqm (qdelay)' of RFC 9332
-        if ( qdelay >= max_delay_thresh_us_ ) {
-            return 1;
+
+        if ( qdelay > min_delay_thresh_us_ ) {
+            return scale_prob( ( qdelay - min_delay_thresh_us_ )/
+                ( max_delay_thresh_us_ - min_delay_thresh_us_ ) );
         }
         
-        if ( qdelay > min_delay_thresh_us_ ) {
-            return (qdelay - min_delay_thresh_us_)/
-                ( max_delay_thresh_us_ - min_delay_thresh_us_ );
-        }
-
         return 0;
     }
 }

--- a/src/packet/l4s_packet_queue.cc
+++ b/src/packet/l4s_packet_queue.cc
@@ -23,28 +23,28 @@ L4SPacketQueue::L4SPacketQueue( const string & args )
         min_qlen_pkt_ = 1;
 }
 
-uint32_t L4SPacketQueue::calculate_l4s_native_prob ( uint64_t qdelay )
+double L4SPacketQueue::calculate_l4s_native_prob ( uint64_t qdelay )
 {
     if ( size_packets() <= min_qlen_pkt_ )
         // Do not mark packets if under min_qlen_pkt_ (default is 1)
-        return 0;
+        return 0.0;
 
     // In both the step and the ramp methods:
     if ( qdelay >= max_delay_thresh_us_ ) {
-            return MAX_PROB;
+            return 1.0;
         }
 
     // Here, qdelay < max_delay_thresh_us_
     
     if ( step_ ) {
-        return 0;
+        return 0.0;
     }
     else {
         // Use a ramp function: 'laqm (qdelay)' of RFC 9332
 
         if ( qdelay > min_delay_thresh_us_ ) {
-            return scale_prob( ( qdelay - min_delay_thresh_us_ )/
-                ( max_delay_thresh_us_ - min_delay_thresh_us_ ) );
+            return ( qdelay - min_delay_thresh_us_ )/
+                ( max_delay_thresh_us_ - min_delay_thresh_us_ );
         }
         
         return 0;

--- a/src/packet/l4s_packet_queue.cc
+++ b/src/packet/l4s_packet_queue.cc
@@ -6,8 +6,7 @@
 using namespace std;
 
 L4SPacketQueue::L4SPacketQueue( const string & args )
-  : AbstractDualPI2PacketQueue(args),
-    max_delay_thresh_us_( get_arg( args, "l4s_max_threshold" ) ),
+  : max_delay_thresh_us_( get_arg( args, "l4s_max_threshold" ) ),
     min_delay_thresh_us_ ( get_arg( args, "l4s_min_threshold" ) ),
     min_qlen_pkt_ ( get_arg( args, "l4s_min_len" ) )
 {   
@@ -23,27 +22,6 @@ L4SPacketQueue::L4SPacketQueue( const string & args )
     if ( min_qlen_pkt_ == 0 )
         min_qlen_pkt_ = 1;
 }
-
-void L4SPacketQueue::enqueue( QueuedPacket && p )
-{
-  assert( good() );
-}
-
-//returns true if packet should be dropped.
-bool L4SPacketQueue::drop_early ()
-{
-
-    return false;
-}
-
-QueuedPacket L4SPacketQueue::dequeue( void )
-{
-    // TODO: check if keep the DroppingPacketQueue ref here
-    QueuedPacket ret = std::move( DroppingPacketQueue::dequeue () );
-
-    return ret;
-}
-
 
 uint32_t L4SPacketQueue::calculate_l4s_native_prob ( uint64_t qdelay )
 {

--- a/src/packet/l4s_packet_queue.hh
+++ b/src/packet/l4s_packet_queue.hh
@@ -5,21 +5,27 @@
 
 #include <random>
 #include <thread>
-#include "dropping_packet_queue.hh"
+#include "abstract_dualpi2_packet_queue.hh"
 
 /*
    L4S queue implementation as part of the DualPI2 implentation described in RFC 9332.
 */
 
-class L4SPacketQueue : public DroppingPacketQueue
+class L4SPacketQueue : public AbstractDualPI2PacketQueue
 {
 private:
-    //This constant is copied from link_queue.hh.
-    //It maybe better to get this in a more reliable way in the future.
-    const static unsigned int PACKET_SIZE = 1504; /* default max TUN payload size */
+    /* L4S native AQM parameters */ 
+    
+    uint64_t max_delay_thresh_us_;
 
+    // Min threshold if using the range method
+    uint64_t min_delay_thresh_us_;
 
+    // Is the marking probability a step or a range function ?
+    bool step_;
 
+    // Minimum queue length for marking to apply
+    uint32_t min_qlen_pkt_;
 
     virtual const std::string & type( void ) const override
     {
@@ -29,7 +35,7 @@ private:
 
     bool drop_early ( void );
 
-    void calculate_drop_prob ( void );
+    
 
 public:
     L4SPacketQueue( const std::string & args );
@@ -37,6 +43,9 @@ public:
     void enqueue( QueuedPacket && p ) override;
 
     QueuedPacket dequeue( void ) override;
+
+    uint32_t calculate_l4s_native_prob ( uint64_t qdelay );
+
 };
 
 #endif /* L4S_PACKET_QUEUE_HH */

--- a/src/packet/l4s_packet_queue.hh
+++ b/src/packet/l4s_packet_queue.hh
@@ -1,0 +1,42 @@
+/* -*-mode:c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#ifndef L4S_PACKET_QUEUE_HH
+#define L4S_PACKET_QUEUE_HH
+
+#include <random>
+#include <thread>
+#include "dropping_packet_queue.hh"
+
+/*
+   L4S queue implementation as part of the DualPI2 implentation described in RFC 9332.
+*/
+
+class L4SPacketQueue : public DroppingPacketQueue
+{
+private:
+    //This constant is copied from link_queue.hh.
+    //It maybe better to get this in a more reliable way in the future.
+    const static unsigned int PACKET_SIZE = 1504; /* default max TUN payload size */
+
+
+
+
+    virtual const std::string & type( void ) const override
+    {
+        static const std::string type_ { "l4s" };
+        return type_;
+    }
+
+    bool drop_early ( void );
+
+    void calculate_drop_prob ( void );
+
+public:
+    L4SPacketQueue( const std::string & args );
+
+    void enqueue( QueuedPacket && p ) override;
+
+    QueuedPacket dequeue( void ) override;
+};
+
+#endif /* L4S_PACKET_QUEUE_HH */

--- a/src/packet/l4s_packet_queue.hh
+++ b/src/packet/l4s_packet_queue.hh
@@ -40,7 +40,7 @@ private:
 public:
     L4SPacketQueue( const std::string & args );
 
-    uint32_t calculate_l4s_native_prob ( uint64_t qdelay );
+    double calculate_l4s_native_prob ( uint64_t qdelay );
 
 };
 

--- a/src/packet/l4s_packet_queue.hh
+++ b/src/packet/l4s_packet_queue.hh
@@ -33,16 +33,12 @@ private:
         return type_;
     }
 
-    bool drop_early ( void );
+    
 
     
 
 public:
     L4SPacketQueue( const std::string & args );
-
-    void enqueue( QueuedPacket && p ) override;
-
-    QueuedPacket dequeue( void ) override;
 
     uint32_t calculate_l4s_native_prob ( uint64_t qdelay );
 

--- a/src/packet/queued_packet.hh
+++ b/src/packet/queued_packet.hh
@@ -9,15 +9,18 @@
 struct QueuedPacket
 {
     uint64_t arrival_time;
+    uint64_t enqueue_time;
     std::string contents;
 
-    QueuedPacket( const std::string & s_contents, uint64_t s_arrival_time )
-        : arrival_time( s_arrival_time ), contents( s_contents )
+    QueuedPacket( const std::string & s_contents, uint64_t s_arrival_time, uint64_t aqm_enqueue_time = 0 )
+        : arrival_time( s_arrival_time ), enqueue_time( aqm_enqueue_time ), contents( s_contents )
     {}
 
     uint64_t sojourn_time_in_ns ( uint64_t ref )
     { 
-        return ref - arrival_time ;
+        /* enqueue_time needs to be initialized */
+        assert (! enqueue_time );
+        return ref - enqueue_time ;
     }
 };
 

--- a/src/packet/queued_packet.hh
+++ b/src/packet/queued_packet.hh
@@ -14,6 +14,11 @@ struct QueuedPacket
     QueuedPacket( const std::string & s_contents, uint64_t s_arrival_time )
         : arrival_time( s_arrival_time ), contents( s_contents )
     {}
+
+    uint64_t sojourn_time_in_ns ( uint64_t ref )
+    { 
+        return ref - arrival_time ;
+    }
 };
 
 #endif /* QUEUED_PACKET_HH */

--- a/src/packet/queued_packet.hh
+++ b/src/packet/queued_packet.hh
@@ -9,18 +9,15 @@
 struct QueuedPacket
 {
     uint64_t arrival_time;
-    uint64_t enqueue_time;
     std::string contents;
 
-    QueuedPacket( const std::string & s_contents, uint64_t s_arrival_time, uint64_t aqm_enqueue_time = 0 )
-        : arrival_time( s_arrival_time ), enqueue_time( aqm_enqueue_time ), contents( s_contents )
+    QueuedPacket( const std::string & s_contents, uint64_t s_arrival_time )
+        : arrival_time( s_arrival_time ), contents( s_contents )
     {}
 
     uint64_t sojourn_time_in_ns ( uint64_t ref )
     { 
-        /* enqueue_time needs to be initialized */
-        assert (! enqueue_time );
-        return ref - enqueue_time ;
+        return ref - arrival_time ;
     }
 };
 

--- a/src/packet/weighted_round_robin_scheduler.cc
+++ b/src/packet/weighted_round_robin_scheduler.cc
@@ -1,0 +1,55 @@
+#include "weighted_round_robin_scheduler.hh"
+
+WRRScheduler::WRRScheduler (L4SPacketQueue & l4s_q, CLASSICPacketQueue & classic_q)
+: AbstractL4SScheduler (l4s_q, classic_q),
+    credit_ ( 0 ),
+    credit_init_ ( 0 ),
+    credit_change_ ( 0 ),
+    classic_weight_ ( 10 ),
+    l4s_weight_ ( MAX_WEIGHT - classic_weight_ )
+{
+    //TODO: initialize credit properly!
+
+}
+
+QueueType WRRScheduler::select_queue ( ) 
+{
+    credit_change_ = 0;
+    unsigned int l4s_len_pkt = l4s_queue_.size_packets();
+    unsigned int classic_len_pkt = classic_queue_.size_packets();
+
+    assert ( l4s_len_pkt != 0 || classic_len_pkt != 0 );
+
+    if ( l4s_len_pkt > 0 && (classic_len_pkt == 0 || credit_ <= 0) ) {
+        // The L4S queue can be dequeued.
+        // Increase the credit using classic_weight_ if classic queue non-empty
+        QueuedPacket* next_pkt = l4s_queue_.peek(); 
+        credit_change_ = classic_len_pkt ? 
+            classic_weight_ * next_pkt->contents.size() : 0 ;
+        
+        return QueueType::L4S;
+    }
+    else if (classic_len_pkt > 0) {
+        /* The classic queue can be dequeued.
+           Decrease the credit using l4s_weight_ if L4S queue non-empty */ 
+        QueuedPacket* next_pkt = classic_queue_.peek(); 
+        credit_change_ = l4s_len_pkt ? 
+            (-1) * l4s_weight_ * next_pkt->contents.size() : 0 ;
+        
+        return QueueType::Classic;
+    }
+    else {
+        // If both queues are empty.
+        // Never happens
+    }
+
+
+
+
+}
+
+void WRRScheduler::apply_credit_change ( )
+{
+    credit_ += credit_change_ ;
+}
+

--- a/src/packet/weighted_round_robin_scheduler.cc
+++ b/src/packet/weighted_round_robin_scheduler.cc
@@ -3,13 +3,14 @@
 WRRScheduler::WRRScheduler (L4SPacketQueue & l4s_q, CLASSICPacketQueue & classic_q)
 : AbstractL4SScheduler (l4s_q, classic_q),
     credit_ ( 0 ),
-    credit_init_ ( 0 ),
     credit_change_ ( 0 ),
     classic_weight_ ( 10 ),
     l4s_weight_ ( MAX_WEIGHT - classic_weight_ )
 {
-    //TODO: initialize credit properly!
-
+    /* Adapted from the initialization of q->c_protection.init in sch_dualpi2.c, using the psched_mtu function.
+       If the L4S weight is higher than the classic, the negative credit_init_ will give priority to the L4S queue.*/
+    
+    credit_init_ = (int32_t)MTU * ( classic_weight_ - l4s_weight_ );
 }
 
 QueueType WRRScheduler::select_queue ( ) 

--- a/src/packet/weighted_round_robin_scheduler.cc
+++ b/src/packet/weighted_round_robin_scheduler.cc
@@ -14,42 +14,37 @@ WRRScheduler::WRRScheduler (L4SPacketQueue & l4s_q, CLASSICPacketQueue & classic
 
 QueueType WRRScheduler::select_queue ( ) 
 {
+    if ( l4s_queue_.empty() && classic_queue_.empty() ) {
+        reset_credit();
+        return QueueType::NONE;
+    }
+
     credit_change_ = 0;
-    unsigned int l4s_len_pkt = l4s_queue_.size_packets();
-    unsigned int classic_len_pkt = classic_queue_.size_packets();
 
-    assert ( l4s_len_pkt != 0 || classic_len_pkt != 0 );
-
-    if ( l4s_len_pkt > 0 && (classic_len_pkt == 0 || credit_ <= 0) ) {
+    if ( not l4s_queue_.empty() && (classic_queue_.empty() || credit_ <= 0) ) {
         // The L4S queue can be dequeued.
         // Increase the credit using classic_weight_ if classic queue non-empty
         QueuedPacket* next_pkt = l4s_queue_.peek(); 
-        credit_change_ = classic_len_pkt ? 
+        credit_change_ = not classic_queue_.empty() ? 
             classic_weight_ * next_pkt->contents.size() : 0 ;
         
         return QueueType::L4S;
     }
-    else if (classic_len_pkt > 0) {
+    else if (not classic_queue_.empty()) {
         /* The classic queue can be dequeued.
            Decrease the credit using l4s_weight_ if L4S queue non-empty */ 
         QueuedPacket* next_pkt = classic_queue_.peek(); 
-        credit_change_ = l4s_len_pkt ? 
+        credit_change_ = not l4s_queue_.empty() ? 
             (-1) * l4s_weight_ * next_pkt->contents.size() : 0 ;
         
         return QueueType::Classic;
     }
-    else {
-        // If both queues are empty.
-        // Never happens
-    }
-
-
-
-
+    // else both queues are empty, handled at the beginning.
 }
 
 void WRRScheduler::apply_credit_change ( )
 {
     credit_ += credit_change_ ;
+    credit_change_ = 0;
 }
 

--- a/src/packet/weighted_round_robin_scheduler.cc
+++ b/src/packet/weighted_round_robin_scheduler.cc
@@ -25,18 +25,18 @@ QueueType WRRScheduler::select_queue ( )
     if ( not l4s_queue_.empty() && (classic_queue_.empty() || credit_ <= 0) ) {
         // The L4S queue can be dequeued.
         // Increase the credit using classic_weight_ if classic queue non-empty
-        QueuedPacket* next_pkt = l4s_queue_.peek(); 
+        QueuedPacket& next_pkt = l4s_queue_.peek(); 
         credit_change_ = not classic_queue_.empty() ? 
-            classic_weight_ * next_pkt->contents.size() : 0 ;
+            classic_weight_ * next_pkt.contents.size() : 0 ;
         
         return QueueType::L4S;
     }
     else if (not classic_queue_.empty()) {
         /* The classic queue can be dequeued.
            Decrease the credit using l4s_weight_ if L4S queue non-empty */ 
-        QueuedPacket* next_pkt = classic_queue_.peek(); 
+        QueuedPacket& next_pkt = classic_queue_.peek(); 
         credit_change_ = not l4s_queue_.empty() ? 
-            (-1) * l4s_weight_ * next_pkt->contents.size() : 0 ;
+            (-1) * l4s_weight_ * next_pkt.contents.size() : 0 ;
         
         return QueueType::Classic;
     }

--- a/src/packet/weighted_round_robin_scheduler.cc
+++ b/src/packet/weighted_round_robin_scheduler.cc
@@ -11,6 +11,7 @@ WRRScheduler::WRRScheduler (L4SPacketQueue & l4s_q, CLASSICPacketQueue & classic
        If the L4S weight is higher than the classic, the negative credit_init_ will give priority to the L4S queue.*/
     
     credit_init_ = (int32_t)MTU * ( classic_weight_ - l4s_weight_ );
+    reset_credit();
 }
 
 QueueType WRRScheduler::select_queue ( ) 

--- a/src/packet/weighted_round_robin_scheduler.hh
+++ b/src/packet/weighted_round_robin_scheduler.hh
@@ -12,8 +12,8 @@ class WRRScheduler : public AbstractL4SScheduler
 {
 private: 
     // From the c_protection struct of the dualpi2 linux code.
-    uint32_t credit_;
-    uint32_t credit_init_;
+    int32_t credit_;
+    int32_t credit_init_;
     unsigned char classic_weight_;
     unsigned char l4s_weight_;
 

--- a/src/packet/weighted_round_robin_scheduler.hh
+++ b/src/packet/weighted_round_robin_scheduler.hh
@@ -1,0 +1,34 @@
+#ifndef WEIGHTED_ROUND_ROBIN_SCHED_HH
+#define WEIGHTED_ROUND_ROBIN_SCHED_HH
+
+#include <queue>
+#include <cassert>
+
+#include "abstract_l4s_scheduler.hh"
+
+#define MAX_WEIGHT 100
+
+class WRRScheduler : public AbstractL4SScheduler
+{
+private: 
+    // From the c_protection struct of the dualpi2 linux code.
+    uint32_t credit_;
+    uint32_t credit_init_;
+    unsigned char classic_weight_;
+    unsigned char l4s_weight_;
+
+    int32_t credit_change_;
+
+    void reset_credit () {
+        credit_ = credit_init_;
+    };
+
+public:
+    WRRScheduler (L4SPacketQueue & l4s_q, CLASSICPacketQueue & classic_q);
+
+    QueueType select_queue( void ) override;
+
+    void apply_credit_change ( void );
+};
+
+#endif /* WEIGHTED_ROUND_ROBIN_SCHED_HH */ 

--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -9,7 +9,7 @@ noinst_LIBRARIES = libutil.a
 
 libutil_a_SOURCES = exception.hh ezio.cc ezio.hh                               \
         file_descriptor.hh file_descriptor.cc netdevice.cc netdevice.hh        \
-	timestamp.cc timestamp.hh                                              \
+	    timestamp.cc timestamp.hh                                              \
         child_process.hh child_process.cc signalfd.hh signalfd.cc              \
         socket.cc socket.hh address.cc address.hh                              \
         system_runner.hh system_runner.cc nat.hh nat.cc                        \
@@ -18,4 +18,5 @@ libutil_a_SOURCES = exception.hh ezio.cc ezio.hh                               \
         poller.hh poller.cc bytestream_queue.hh bytestream_queue.cc            \
         event_loop.hh event_loop.cc                                            \
         temp_file.hh temp_file.cc dns_server.hh dns_server.cc                  \
-        socketpair.hh socketpair.cc
+        socketpair.hh socketpair.cc                                            \
+        timerfd.hh timerfd.cc 

--- a/src/util/timerfd.cc
+++ b/src/util/timerfd.cc
@@ -1,0 +1,26 @@
+/* Adapted from project Ringmaster - timerfd.cc 
+   Original source: https://github.com/microsoft/ringmaster/blob/main/src/util/timerfd.cc */
+
+#include <unistd.h>
+
+#include "timerfd.hh"
+#include "exception.hh"
+
+using namespace std;
+
+Timerfd::Timerfd( int clockid, int flags )
+  : FileDescriptor( SystemCall( "timerfd_create", timerfd_create(clockid, flags) ) )
+{
+    clockid_ = clockid;
+    flags_ = flags;
+}
+
+void Timerfd::set_time( const timespec & initial_expiration,
+                       const timespec & interval )
+{
+    itimerspec its;
+    its.it_value = initial_expiration;
+    its.it_interval = interval;
+
+    SystemCall( "timerfd set_time", timerfd_settime(fd_num(), 0, &its, nullptr) );
+}

--- a/src/util/timerfd.hh
+++ b/src/util/timerfd.hh
@@ -1,0 +1,25 @@
+/* Adapted from project Ringmaster - timerfd.hh 
+   Original source: https://github.com/microsoft/ringmaster/blob/main/src/util/timerfd.hh */
+
+#ifndef TIMERFD_HH
+#define TIMERFD_HH
+
+#include <time.h>
+#include <sys/timerfd.h>
+
+#include "file_descriptor.hh"
+
+class Timerfd : public FileDescriptor
+{
+private:
+    int clockid_;
+    int flags_;
+
+public:
+    Timerfd(int clockid = CLOCK_MONOTONIC, int flags = TFD_NONBLOCK);
+
+    void set_time( const timespec & initial_expiration,
+                    const timespec & interval );
+};
+
+#endif /* TIMERFD_HH */

--- a/src/util/timestamp.cc
+++ b/src/util/timestamp.cc
@@ -26,3 +26,24 @@ uint64_t timestamp( void )
 {
     return raw_timestamp() - initial_timestamp();
 }
+
+/* Same in ns */
+
+uint64_t raw_timestamp_ns( void )
+{
+    timespec ts;
+    SystemCall( "clock_gettime", clock_gettime( CLOCK_REALTIME, &ts ) );
+
+    return ts.tv_nsec + uint64_t( ts.tv_sec ) * 1000000000;
+}
+
+uint64_t initial_timestamp_ns( void )
+{
+    static uint64_t initial_value_ns = raw_timestamp_ns();
+    return initial_value_ns;
+}
+
+uint64_t timestamp_ns( void )
+{
+    return raw_timestamp_ns() - initial_timestamp_ns();
+}

--- a/src/util/timestamp.hh
+++ b/src/util/timestamp.hh
@@ -8,4 +8,7 @@
 uint64_t timestamp( void );
 uint64_t initial_timestamp( void );
 
+uint64_t timestamp_ns( void );
+uint64_t initial_timestamp_ns( void );
+
 #endif /* TIMESTAMP_HH */


### PR DESCRIPTION
PR in progress #2
Wrote bash scripts to test l4s flow vs classic flow. Generates live graphs or log files - may need to write python scripts to further visualize and analyze. 

./compare [time] for live graphs
./compare_log [time] for .log outputs regarding the separate flows (classic and dualPI2 0x01 flows) for each dualPI2 and classic flows (codex in this case). No support to visualize these yet. 

Classic flow:
[Screencast from 2025-06-30 10-18-29.webm](https://github.com/user-attachments/assets/fd7e0fed-deee-4fdc-a9ae-f7397e3db5b7)

dualPI2 flow:

[Screencast from 2025-06-30 10-24-26.webm](https://github.com/user-attachments/assets/fdc53b44-997b-4267-8f9e-b350d8c97921)

Observations:

- Much more queuing delay in the dualPI2 flow.
- Average throughput is the same with similar variance

I think this is expected because dualPI2 (used in L4S-style queueing) is designed to mark packets rather than drop them, relying on congestion control algorithms like SCReAM to respond to ECN marks. Since no congestion controller is currently used, packets continue to build up in the queue, leading to increased delay.

Codel which I used for the classic flow information actually drops  packets to signal congestion. Something like if the delay exceeds a target for too long, it drops packets to force the sender to slow down. I think with the dualPI2 implementation right now (correct me if I'm wrong), it marks packets using ECN bits (ECN-CE) to gently signal congestion early but does not get dropped smartly (holds a long queue). 

Next steps:
Use SCeAM with congestion control for l4s instead of iperf3. 